### PR TITLE
implemented DropMessage; implemented ModelObject

### DIFF
--- a/src/main/java/de/qabel/core/drop/DropMessage.java
+++ b/src/main/java/de/qabel/core/drop/DropMessage.java
@@ -1,0 +1,69 @@
+package de.qabel.core.drop;
+
+import java.util.Date;
+
+public class DropMessage<T extends ModelObject>{
+    private int version;
+    private long time;
+    private String acknowledgeID;
+    private String sender;
+    private Class<T> modelObject;
+    private T data;
+
+    public DropMessage(int version, Date time, String acknowledgeID, String sender, Class<T> modelObject, T data) {
+        setVersion(version);
+        setTime(time);
+        setSender(sender);
+        setSender(sender);
+        setModelObject(modelObject);
+        setData(data);
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(Date time) {
+        this.time = time.getTime();
+    }
+
+    public String getAcknowledgeID() {
+        return acknowledgeID;
+    }
+
+    public void setAcknowledgeID(String acknowledgeID) {
+        this.acknowledgeID = acknowledgeID;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    public Class<T> getModelObject() {
+        return modelObject;
+    }
+
+    public void setModelObject(Class<T> modelObject) {
+        this.modelObject = modelObject;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/de/qabel/core/drop/ModelObject.java
+++ b/src/main/java/de/qabel/core/drop/ModelObject.java
@@ -1,0 +1,5 @@
+package de.qabel.core.drop;
+
+
+public abstract class ModelObject {
+}


### PR DESCRIPTION
needed for #24
I can't build an api without the needed classes.

If you wonder about why `private long time` is not of type Date:
The setter sets it as long because in JSON it will be an int.
Tell me if that is not OK, I'm not so sure about it. I thought about easier serialisation.
