### PR TITLE
Fixed parsing of multipart by using parseHeadless

### DIFF
--- a/src/main/java/de/qabel/core/http/DropHTTP.java
+++ b/src/main/java/de/qabel/core/http/DropHTTP.java
@@ -59,7 +59,7 @@ public class DropHTTP {
 			if (responseCode == 200) {
 				InputStream inputstream = conn.getInputStream();
 				MimeTokenStream stream = new MimeTokenStream();
-				stream.parse(inputstream);
+				stream.parseHeadless(inputstream, conn.getContentType());
 				for (EntityState state = stream.getState();
 					 state != EntityState.T_END_OF_STREAM;
 					 state = stream.next()) {


### PR DESCRIPTION
HttpURLConnection's InputStream does not include HTTP header data.
Therefore, the mime stream parser couldn't use the content type
information transported in the content type http header field.

By using parseHeadless instead of parse, the mime parser gets the
content type info by parameter and not from the input stream itself.

Fixes #117 in combination with Qabel/qabel-drop#13
