### PR TITLE
fix NullPointerException in DropController.handleDrop()

### DIFF
--- a/src/main/java/de/qabel/core/drop/DropDeserializer.java
+++ b/src/main/java/de/qabel/core/drop/DropDeserializer.java
@@ -9,6 +9,8 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
+import de.qabel.core.module.ModuleManager;
+
 
 public class DropDeserializer implements JsonDeserializer<DropMessage<ModelObject>> {
     @Override
@@ -23,7 +25,7 @@ public class DropDeserializer implements JsonDeserializer<DropMessage<ModelObjec
 
         ModelObject m;
         try {
-            ClassLoader loader = ClassLoader.getSystemClassLoader();
+            ClassLoader loader = ModuleManager.LOADER;
 
             @SuppressWarnings("unchecked")
             Class<? extends ModelObject> cls = (Class<? extends ModelObject>) loader

--- a/src/main/java/de/qabel/core/module/ModuleManager.java
+++ b/src/main/java/de/qabel/core/module/ModuleManager.java
@@ -3,6 +3,8 @@ package de.qabel.core.module;
 import de.qabel.core.storage.StorageConnection;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -13,6 +15,19 @@ import de.qabel.core.config.Settings;
 import de.qabel.core.drop.DropController;
 
 public class ModuleManager {
+	static public class ClassLoader extends URLClassLoader{
+	    public ClassLoader() {
+	        super(new URL[0]);
+	    }
+
+	    @Override
+	    public void addURL(URL url) {
+	        super.addURL(url);
+	    }
+	}
+
+	public final static ClassLoader LOADER = new ClassLoader();
+
 	/**
 	 * <pre>
 	 *           0..*     0..*
@@ -83,7 +98,8 @@ public class ModuleManager {
 	
 	public void startModule(File jar, String className) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
 		try {
-			ClassLoader cld = URLClassLoader.newInstance(new URL[] { jar.toURI().toURL() }, ClassLoader.getSystemClassLoader() );
+			ClassLoader cld = LOADER;
+			cld.addURL(jar.toURI().toURL());
 			startModule(Class.forName(className, true, cld));
 		} catch (MalformedURLException e) {
 			e.printStackTrace();


### PR DESCRIPTION
The problem was, that DropDeserialiser drops unknown messages without any info. It uses the default system ClassLoader which wasn't aware of the jar which contains the module. so loading a ModelObject resulted in an Exception which was silently ignored and returned null.

The DropController does not expect null-values, so it added the null-value to the list of received messages. afterwards when handleDrop was called on the null-value, it tried to get the module object from null and therefore crashed.
