### PR TITLE
GCM and CTR mode with 96 bit nonce

### DIFF
--- a/src/test/java/de/qabel/core/crypto/CryptoUtilsTest.java
+++ b/src/test/java/de/qabel/core/crypto/CryptoUtilsTest.java
@@ -7,7 +7,6 @@ import java.security.InvalidKeyException;
 import javax.crypto.BadPaddingException;
 
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;


### PR DESCRIPTION
This reduces the nonce length to 96 bit as it is recommended for GCM. With test vectors from NIST and IETF our implementation is shown to be correct.
This closes #138.
