### PR TITLE
Removed usage of model class Contacts from drop interface

### DIFF
--- a/src/main/java/de/qabel/core/drop/Drop.java
+++ b/src/main/java/de/qabel/core/drop/Drop.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import de.qabel.core.config.Contact;
-import de.qabel.core.config.Contacts;
 import de.qabel.core.crypto.*;
 import de.qabel.core.http.DropHTTP;
 
@@ -139,14 +138,14 @@ public class Drop<T extends ModelObject> {
      * @param contacts Contacts to check the signature with
      * @return Retrieved, encrypted Dropmessages.
      */
-    public Collection<DropMessage> retrieve(URL url, Contacts contacts) {
+    public Collection<DropMessage> retrieve(URL url, Collection<Contact> contacts) {
         DropHTTP http = new DropHTTP();
         Collection<byte[]> cipherMessages = http.receiveMessages(url);
         Collection<DropMessage> plainMessages = new ArrayList<DropMessage>();
         String plainJson = null;
 
         for (byte[] cipherMessage : cipherMessages) {
-            for (Contact c : contacts.getContacts()) {
+            for (Contact c : contacts) {
                 try {
 					plainJson = decryptDrop(cipherMessage,
 					        c.getContactOwner().getPrimaryKeyPair(),

--- a/src/main/java/de/qabel/core/drop/DropController.java
+++ b/src/main/java/de/qabel/core/drop/DropController.java
@@ -78,7 +78,7 @@ public class DropController {
 		for (DropServer server : servers) {
 			Drop drop = new Drop<>();
 			Collection<DropMessage<? extends ModelObject>> results = drop
-					.retrieve(server.getUrl(), getContacts());
+					.retrieve(server.getUrl(), getContacts().getContacts());
 			for (DropMessage<? extends ModelObject> dm : results) {
 				handleDrop(dm);
 			}

--- a/src/test/java/de/qabel/core/drop/DropTest.java
+++ b/src/test/java/de/qabel/core/drop/DropTest.java
@@ -203,7 +203,7 @@ public class DropTest {
         
         Drop d = new Drop();
 
-        Collection<DropMessage<ModelObject>> result = d.retrieve(contactUrl, contacts);
+        Collection<DropMessage<ModelObject>> result = d.retrieve(contactUrl, contacts.getContacts());
         //We expect at least one drop message from "foo"
         Assert.assertTrue(result.size() >= 1);
         for (DropMessage<ModelObject> dm : result){
@@ -237,7 +237,7 @@ public class DropTest {
 
         Drop d = new Drop();
 
-        Collection<DropMessage<ModelObject>> result = d.retrieve(contactUrl, contacts);
+        Collection<DropMessage<ModelObject>> result = d.retrieve(contactUrl, contacts.getContacts());
         //We expect at least one drop message from "foo"
         Assert.assertTrue(result.size() >= 1);
         for (DropMessage<ModelObject> dm : result){


### PR DESCRIPTION
According to the model-view-controller concept, the Contacts class
should not be exposed in the drop interface.
Instead, a collection of "Contact"s is used.

I remember that @Gottox raised this issue somewhere, but I cannot find the context.
