### PR TITLE
Fixes singular/plural naming inconsistencies in config classes

### DIFF
--- a/src/main/java/de/qabel/core/config/Accounts.java
+++ b/src/main/java/de/qabel/core/config/Accounts.java
@@ -13,21 +13,21 @@ public class Accounts {
 	 *           accounts        &gt;       account
 	 * </pre>
 	 */
-	private final Set<Account> account = new HashSet<Account>();
+	private final Set<Account> accounts = new HashSet<Account>();
 
-	public Set<Account> getAccount() {
-		return Collections.unmodifiableSet(this.account);
+	public Set<Account> getAccounts() {
+		return Collections.unmodifiableSet(this.accounts);
 	}
 	
 	public boolean add(Account account) {
-		return this.account.add(account);
+		return this.accounts.add(account);
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((account == null) ? 0 : account.hashCode());
+		result = prime * result + ((accounts == null) ? 0 : accounts.hashCode());
 		return result;
 	}
 
@@ -40,10 +40,10 @@ public class Accounts {
 		if (getClass() != obj.getClass())
 			return false;
 		Accounts other = (Accounts) obj;
-		if (account == null) {
-			if (other.account != null)
+		if (accounts == null) {
+			if (other.accounts != null)
 				return false;
-		} else if (!account.equals(other.account))
+		} else if (!accounts.equals(other.accounts))
 			return false;
 		return true;
 	}

--- a/src/main/java/de/qabel/core/config/AccountsTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/AccountsTypeAdapter.java
@@ -15,7 +15,7 @@ public class AccountsTypeAdapter extends TypeAdapter<Accounts> {
 	public void write(JsonWriter out, Accounts value) throws IOException {
 		out.beginArray();
 		Gson gson = new Gson();
-		Set<Account> set = value.getAccount();
+		Set<Account> set = value.getAccounts();
 		TypeAdapter<Account> adapter = gson.getAdapter(Account.class);
 		for(Account account : set) {
 			adapter.write(out, account);

--- a/src/main/java/de/qabel/core/config/DropServers.java
+++ b/src/main/java/de/qabel/core/config/DropServers.java
@@ -12,14 +12,14 @@ public class DropServers {
 	 *           dropServers        &gt;       dropServer
 	 * </pre>
 	 */
-	private final Set<DropServer> dropServer = new HashSet<DropServer>();
+	private final Set<DropServer> dropServers = new HashSet<DropServer>();
 
-	public Set<DropServer> getDropServer() {
-		return Collections.unmodifiableSet(this.dropServer);
+	public Set<DropServer> getDropServers() {
+		return Collections.unmodifiableSet(this.dropServers);
 	}
 	
 	public boolean add(DropServer dropServer) {
-		return this.dropServer.add(dropServer);
+		return this.dropServers.add(dropServer);
 	}
 
 	@Override
@@ -27,7 +27,7 @@ public class DropServers {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result
-				+ ((dropServer == null) ? 0 : dropServer.hashCode());
+				+ ((dropServers == null) ? 0 : dropServers.hashCode());
 		return result;
 	}
 
@@ -40,10 +40,10 @@ public class DropServers {
 		if (getClass() != obj.getClass())
 			return false;
 		DropServers other = (DropServers) obj;
-		if (dropServer == null) {
-			if (other.dropServer != null)
+		if (dropServers == null) {
+			if (other.dropServers != null)
 				return false;
-		} else if (!dropServer.equals(other.dropServer))
+		} else if (!dropServers.equals(other.dropServers))
 			return false;
 		return true;
 	}

--- a/src/main/java/de/qabel/core/config/DropServersTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/DropServersTypeAdapter.java
@@ -15,7 +15,7 @@ public class DropServersTypeAdapter extends TypeAdapter<DropServers> {
 	public void write(JsonWriter out, DropServers value) throws IOException {
 		out.beginArray();
 		Gson gson = new Gson();
-		Set<DropServer> set = value.getDropServer();
+		Set<DropServer> set = value.getDropServers();
 		TypeAdapter<DropServer> adapter = gson.getAdapter(DropServer.class);
 		for(DropServer dropServer : set) {
 			adapter.write(out, dropServer);

--- a/src/main/java/de/qabel/core/config/StorageServers.java
+++ b/src/main/java/de/qabel/core/config/StorageServers.java
@@ -12,14 +12,14 @@ public class StorageServers {
 	 *           storageServers        &gt;       storageServer
 	 * </pre>
 	 */
-	private final Set<StorageServer> storageServer = new HashSet<StorageServer>();
+	private final Set<StorageServer> storageServers = new HashSet<StorageServer>();
 
-	public Set<StorageServer> getStorageServer() {
-		return Collections.unmodifiableSet(this.storageServer);
+	public Set<StorageServer> getStorageServers() {
+		return Collections.unmodifiableSet(this.storageServers);
 	}
 	
 	public boolean add(StorageServer storageServer) {
-		return this.storageServer.add(storageServer);
+		return this.storageServers.add(storageServer);
 	}
 
 	@Override
@@ -27,7 +27,7 @@ public class StorageServers {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result
-				+ ((storageServer == null) ? 0 : storageServer.hashCode());
+				+ ((storageServers == null) ? 0 : storageServers.hashCode());
 		return result;
 	}
 
@@ -40,10 +40,10 @@ public class StorageServers {
 		if (getClass() != obj.getClass())
 			return false;
 		StorageServers other = (StorageServers) obj;
-		if (storageServer == null) {
-			if (other.storageServer != null)
+		if (storageServers == null) {
+			if (other.storageServers != null)
 				return false;
-		} else if (!storageServer.equals(other.storageServer))
+		} else if (!storageServers.equals(other.storageServers))
 			return false;
 		return true;
 	}

--- a/src/main/java/de/qabel/core/config/StorageServersTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/StorageServersTypeAdapter.java
@@ -15,7 +15,7 @@ public class StorageServersTypeAdapter extends TypeAdapter<StorageServers> {
 	public void write(JsonWriter out, StorageServers value) throws IOException {
 		out.beginArray();
 		Gson gson = new Gson();
-		Set<StorageServer> set = value.getStorageServer();
+		Set<StorageServer> set = value.getStorageServers();
 		TypeAdapter<StorageServer> adapter = gson.getAdapter(StorageServer.class);
 		for(StorageServer storageServer : set) {
 			adapter.write(out, storageServer);

--- a/src/main/java/de/qabel/core/config/StorageVolumes.java
+++ b/src/main/java/de/qabel/core/config/StorageVolumes.java
@@ -12,14 +12,14 @@ public class StorageVolumes {
 	 *           storageVolumes        &gt;       storageVolume
 	 * </pre>
 	 */
-	private final Set<StorageVolume> storageVolume = new HashSet<StorageVolume>();
+	private final Set<StorageVolume> storageVolumes = new HashSet<StorageVolume>();
 
-	public Set<StorageVolume> getStorageVolume() {
-		return Collections.unmodifiableSet(this.storageVolume);
+	public Set<StorageVolume> getStorageVolumes() {
+		return Collections.unmodifiableSet(this.storageVolumes);
 	}
 	
 	public boolean add(StorageVolume storageVolume) {
-		return this.storageVolume.add(storageVolume);
+		return this.storageVolumes.add(storageVolume);
 	}
 
 	@Override
@@ -27,7 +27,7 @@ public class StorageVolumes {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result
-				+ ((storageVolume == null) ? 0 : storageVolume.hashCode());
+				+ ((storageVolumes == null) ? 0 : storageVolumes.hashCode());
 		return result;
 	}
 
@@ -40,10 +40,10 @@ public class StorageVolumes {
 		if (getClass() != obj.getClass())
 			return false;
 		StorageVolumes other = (StorageVolumes) obj;
-		if (storageVolume == null) {
-			if (other.storageVolume != null)
+		if (storageVolumes == null) {
+			if (other.storageVolumes != null)
 				return false;
-		} else if (!storageVolume.equals(other.storageVolume))
+		} else if (!storageVolumes.equals(other.storageVolumes))
 			return false;
 		return true;
 	}

--- a/src/main/java/de/qabel/core/config/StorageVolumesTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/StorageVolumesTypeAdapter.java
@@ -15,7 +15,7 @@ public class StorageVolumesTypeAdapter extends TypeAdapter<StorageVolumes> {
 	public void write(JsonWriter out, StorageVolumes value) throws IOException {
 		out.beginArray();
 		Gson gson = new Gson();
-		Set<StorageVolume> set = value.getStorageVolume();
+		Set<StorageVolume> set = value.getStorageVolumes();
 		TypeAdapter<StorageVolume> adapter = gson.getAdapter(StorageVolume.class);
 		for(StorageVolume storageVolume : set) {
 			adapter.write(out, storageVolume);

--- a/src/main/java/de/qabel/core/drop/DropController.java
+++ b/src/main/java/de/qabel/core/drop/DropController.java
@@ -74,7 +74,7 @@ public class DropController {
 	 */
 	public void retrieve() {
 		HashSet<DropServer> servers = new HashSet<DropServer>(getDropServers()
-				.getDropServer());
+				.getDropServers());
 		for (DropServer server : servers) {
 			Drop drop = new Drop<>();
 			Collection<DropMessage<? extends ModelObject>> results = drop


### PR DESCRIPTION
This changes some names of collection members and collection returning
getters to indicate the plural.

Closes #103
