### PR TITLE
Fixed inconsistency in QblPrimaryPublicKey

### DIFF
--- a/src/main/java/de/qabel/core/crypto/QblPrimaryKeyPair.java
+++ b/src/main/java/de/qabel/core/crypto/QblPrimaryKeyPair.java
@@ -1,5 +1,6 @@
 package de.qabel.core.crypto;
 
+import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -88,6 +89,11 @@ public class QblPrimaryKeyPair extends QblKeyPair {
 		signKeyPairs.add(qskp);
 		signPrivateKeys.add(qskp.getRSAPrivateKey());
 		signPublicKeys.add(qskp.getQblSignPublicKey());
+		try {
+			qblPrimaryPublicKey.attachSignPublicKey(qskp.getQblSignPublicKey());
+		} catch (InvalidKeyException e) {
+			new RuntimeException("Newly created subkey has invalid signature.", e);
+		}
 	}
 
 	/**
@@ -104,6 +110,11 @@ public class QblPrimaryKeyPair extends QblKeyPair {
 		encKeyPairs.add(qekp);
 		encPrivateKeys.add(qekp.getRSAPrivateKey());
 		encPublicKeys.add(qekp.getQblEncPublicKey());
+		try {
+			qblPrimaryPublicKey.attachEncPublicKey(qekp.getQblEncPublicKey());
+		} catch (InvalidKeyException e) {
+			new RuntimeException("Newly created subkey has invalid signature.", e);
+		}
 	}
 
 	public List<QblEncKeyPair> getEncKeyPairs() {

--- a/src/test/java/de/qabel/core/crypto/QblPrimaryPublicKeyInconsistencyTest.java
+++ b/src/test/java/de/qabel/core/crypto/QblPrimaryPublicKeyInconsistencyTest.java
@@ -1,0 +1,14 @@
+package de.qabel.core.crypto;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QblPrimaryPublicKeyInconsistencyTest {
+	@Test
+	public void inconsistencyTest() {
+		QblPrimaryKeyPair pkp = QblKeyFactory.getInstance().generateQblPrimaryKeyPair();
+		QblPrimaryPublicKey ppp = pkp.getQblPrimaryPublicKey();
+		Assert.assertFalse(ppp.getEncPublicKeys().isEmpty());
+		Assert.assertFalse(ppp.getSignPublicKeys().isEmpty());
+	}
+}


### PR DESCRIPTION
The two lists for signing and encryption sub-public keys are not updated by the QblPrimaryKeyPair constructor.