### PR TITLE
Support for multiple drop message binary transport formats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.+'
 	compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.51'
 	compile group: 'org.apache.james', name: 'apache-mime4j', version: '0.7.2'
+	compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.+'
 }
 
 task wrapper(type: Wrapper) {

--- a/src/main/java/de/qabel/core/crypto/AbstractBinaryDropMessage.java
+++ b/src/main/java/de/qabel/core/crypto/AbstractBinaryDropMessage.java
@@ -1,0 +1,133 @@
+package de.qabel.core.crypto;
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import de.qabel.core.config.Contact;
+import de.qabel.core.drop.DropDeserializer;
+import de.qabel.core.drop.DropMessage;
+import de.qabel.core.drop.DropSerializer;
+import de.qabel.core.exceptions.QblDropPayloadSizeException;
+import de.qabel.core.exceptions.QblVersionMismatchException;
+
+/**
+ * Abstract drop message in a binary transport format.
+ */
+public abstract class AbstractBinaryDropMessage {
+	private static final Logger logger = LogManager
+			.getLogger(AbstractBinaryDropMessage.class.getName());
+
+	private byte[] plainPayload;
+
+	public AbstractBinaryDropMessage(DropMessage<?> dropMessage)
+			throws QblDropPayloadSizeException {
+		this.plainPayload = serializeMessage(dropMessage);
+		if (plainPayload.length > getPayloadSize()) {
+			throw new QblDropPayloadSizeException();
+		}
+	}
+
+	public AbstractBinaryDropMessage(byte[] binaryMessage)
+			throws QblVersionMismatchException {
+		if (binaryMessage.length != getTotalSize()) {
+			logger.error("Unexpected message size. Is: " + binaryMessage.length
+					+ " Should: " + getTotalSize());
+			throw new QblVersionMismatchException();
+		}
+		if (binaryMessage[0] != getVersion()) {
+			throw new QblVersionMismatchException();
+		}
+	}
+
+	abstract public byte getVersion();
+
+	abstract int getTotalSize();
+
+	abstract int getPayloadSize();
+
+	private static byte[] serializeMessage(DropMessage<?> dropMessage) {
+		Gson gson = new GsonBuilder().registerTypeAdapter(DropMessage.class,
+				new DropSerializer()).create();
+		return gson.toJson(dropMessage).getBytes();
+	}
+
+	/**
+	 * Deserializes the message
+	 *
+	 * @param plainJson plain Json String
+	 * @return deserialized Dropmessage or null if deserialization error
+	 *         occurred.
+	 */
+	private static DropMessage<?> deserialize(String plainJson) {
+		Gson gson = new GsonBuilder().registerTypeAdapter(DropMessage.class,
+				new DropDeserializer()).create();
+		try {
+			return gson.fromJson(plainJson, DropMessage.class);
+		} catch (JsonSyntaxException e) {
+			logger.debug("Deserialization failed due to invalid json syntax", e);
+			return null;
+		}
+	}
+
+	byte[] getPaddedMessage() {
+		return Arrays.copyOf(plainPayload, getPayloadSize());
+	}
+
+	private static byte[] discardPaddingBytes(byte[] paddedMessage) {
+		int paddingLen = 0;
+		int pos = paddedMessage.length - 1;
+		while (pos >= 0 && paddedMessage[pos--] == 0) {
+			paddingLen++;
+		}
+		return Arrays.copyOf(paddedMessage, paddedMessage.length - paddingLen);
+	}
+
+	/**
+	 * Assembles a binary transport message for the given recipient.
+	 * 
+	 * @param recipient Recipient of the message.
+	 * @return assembled binary message.
+	 */
+	abstract public byte[] assembleMessageFor(Contact recipient);
+
+	abstract byte[] disassembleRawMessageFrom(Contact sender);
+
+	/**
+	 * Disassemble binary transport message assuming it sent by the given
+	 * sender.
+	 * 
+	 * @param sender Assumed sender.
+	 * @return Disassembled drop message or null if either the sender assumption
+	 *         was wrong or the message verification faild.
+	 */
+	public DropMessage<?> disassembleMessageFrom(Contact sender) {
+		byte[] rawPlainText = disassembleRawMessageFrom(sender);
+		if (rawPlainText == null) {
+			// tried wrong sender
+			return null;
+		}
+		DropMessage<?> dropMessage = deserialize(new String(
+				discardPaddingBytes(rawPlainText)));
+		if (dropMessage == null) {
+			logger.debug("Message could not be deserialized. Msg: "
+					+ new String(rawPlainText));
+			return null;
+		}
+		// spoofing detection currently not supported
+		// if (dropMessage.getSender() != new
+		// String(sender.getSignPublicKeys().get(0).getPublicKeyFingerprint()))
+		// {
+		// // invalid sender claim
+		// logger.info("Drop message contained spoofed sender field.");
+		// return null;
+		// }
+		return dropMessage;
+	}
+
+}

--- a/src/main/java/de/qabel/core/crypto/BinaryDropMessageV0.java
+++ b/src/main/java/de/qabel/core/crypto/BinaryDropMessageV0.java
@@ -1,0 +1,135 @@
+package de.qabel.core.crypto;
+
+import java.security.InvalidKeyException;
+import java.util.Arrays;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import de.qabel.core.config.Contact;
+import de.qabel.core.drop.DropMessage;
+import de.qabel.core.exceptions.QblDropPayloadSizeException;
+import de.qabel.core.exceptions.QblVersionMismatchException;
+
+/**
+ * Drop message in binary transport format version 0
+ */
+public class BinaryDropMessageV0 extends AbstractBinaryDropMessage {
+	private static final byte VERSION = 0;
+	private static final int HEADER_SIZE = 1;
+	private static final int PAYLOAD_SIZE = 2048;
+	private byte[] encMessage, encKey, signature, signedData;
+
+	private static final Logger logger = LogManager
+			.getLogger(BinaryDropMessageV0.class.getName());
+
+	public BinaryDropMessageV0(DropMessage<?> dropMessage)
+			throws QblDropPayloadSizeException {
+		super(dropMessage);
+	}
+
+	public BinaryDropMessageV0(byte[] binaryMessage)
+			throws QblVersionMismatchException {
+		super(binaryMessage);
+		encKey = Arrays.copyOfRange(binaryMessage, HEADER_SIZE, HEADER_SIZE
+				+ CryptoUtils.ENCRYPTED_AES_KEY_SIZE_BYTE);
+		encMessage = Arrays.copyOfRange(binaryMessage, HEADER_SIZE
+				+ CryptoUtils.ENCRYPTED_AES_KEY_SIZE_BYTE, HEADER_SIZE
+				+ CryptoUtils.ENCRYPTED_AES_KEY_SIZE_BYTE
+				+ CryptoUtils.SYMM_NONCE_SIZE_BYTE + getPayloadSize());
+		signature = Arrays.copyOfRange(binaryMessage, getTotalSize()
+				- CryptoUtils.RSA_SIGNATURE_SIZE_BYTE, getTotalSize());
+		signedData = Arrays.copyOfRange(binaryMessage, HEADER_SIZE, HEADER_SIZE
+				+ CryptoUtils.ENCRYPTED_AES_KEY_SIZE_BYTE
+				+ CryptoUtils.SYMM_NONCE_SIZE_BYTE + getPayloadSize());
+	}
+
+	@Override
+	public byte getVersion() {
+		return VERSION;
+	}
+
+	byte[] getHeader() {
+		return new byte[] { VERSION };
+	}
+
+	@Override
+	int getPayloadSize() {
+		return PAYLOAD_SIZE;
+	}
+
+	@Override
+	int getTotalSize() {
+		return PAYLOAD_SIZE + HEADER_SIZE
+				+ CryptoUtils.ENCRYPTED_AES_KEY_SIZE_BYTE
+				+ CryptoUtils.SYMM_NONCE_SIZE_BYTE
+				+ CryptoUtils.RSA_SIGNATURE_SIZE_BYTE;
+	}
+
+	private byte[] buildBody(Contact recipient) {
+		CryptoUtils cu = new CryptoUtils();
+		SecretKey aesKey = cu.generateSymmetricKey();
+
+		try {
+			encKey = cu.rsaEncryptForRecipient(aesKey.getEncoded(), recipient
+					.getEncryptionPublicKeys().get(0));
+			encMessage = cu.encryptSymmetric(getPaddedMessage(), aesKey);
+		} catch (InvalidKeyException e) {
+			// should not happen
+			logger.error("Invalid key", e);
+			throw new RuntimeException(e);
+		}
+		signedData = ArrayUtils.addAll(encKey, encMessage);
+		signature = cu.createSignature(signedData, recipient.getContactOwner()
+				.getPrimaryKeyPair().getSignKeyPairs().get(0));
+
+		return ArrayUtils.addAll(signedData, signature);
+	}
+
+	public byte[] assembleMessageFor(Contact recipient) {
+		return ArrayUtils.addAll(getHeader(), buildBody(recipient));
+	}
+
+	public byte[] disassembleRawMessageFrom(Contact sender) {
+		CryptoUtils cu = new CryptoUtils();
+		try {
+			if (!cu.validateSignature(signedData, signature, sender
+					.getSignPublicKeys().get(0))) {
+				logger.debug("Invalid signature.");
+				return null;
+			}
+		} catch (InvalidKeyException e) {
+			logger.debug("Invalid signing key");
+			return null;
+		}
+
+		// Decrypt RSA encrypted AES key and decrypt encrypted data with AES key
+		byte[] rawAesKey;
+		try {
+			rawAesKey = cu.rsaDecrypt(encKey, sender.getContactOwner()
+					.getPrimaryKeyPair().getQblEncPrivateKeys().get(0));
+		} catch (InvalidKeyException e) {
+			logger.debug("Invalid decryption key");
+			return null;
+		}
+		if (rawAesKey == null) {
+			// decryption failed
+			logger.debug("Message not meant for this sender");
+			return null;
+		}
+
+		byte[] rawPlainText;
+		try {
+			rawPlainText = cu.decryptSymmetric(encMessage, new SecretKeySpec(
+					rawAesKey, CryptoUtils.SYMM_KEY_ALGORITHM));
+		} catch (InvalidKeyException e) {
+			logger.debug("Invalid AES key");
+			return null;
+		}
+		return rawPlainText;
+	}
+}

--- a/src/main/java/de/qabel/core/crypto/CryptoUtils.java
+++ b/src/main/java/de/qabel/core/crypto/CryptoUtils.java
@@ -50,7 +50,7 @@ public class CryptoUtils {
 	private final static String SYMM_GCM_TRANSFORMATION = "AES/GCM/NoPadding";
 	private final static int SYMM_GCM_READ_SIZE_BYTE = 4096; // Should be multiple of 4096 byte due to flash block size.
 	private final static int SYMM_IV_SIZE_BYTE = 16;
-	private final static int SYMM_NONCE_SIZE_BYTE = 12;
+	final static int SYMM_NONCE_SIZE_BYTE = 12;
 	private final static int AES_KEY_SIZE_BYTE = 32;
 	private final static int AES_KEY_SIZE_BIT = AES_KEY_SIZE_BYTE * 8;
 	private final static int ENCRYPTED_AES_KEY_SIZE_BYTE = 256;
@@ -177,7 +177,7 @@ public class CryptoUtils {
 	 *            Signature key to sign with
 	 * @return Signature over SHA512 sum of message
 	 */
-	private byte[] createSignature(byte[] message, QblSignKeyPair signatureKey) {
+	byte[] createSignature(byte[] message, QblSignKeyPair signatureKey) {
 		byte[] sha512Sum = getSHA512sum(message);
 		return rsaSign(sha512Sum, signatureKey);
 	}
@@ -276,7 +276,7 @@ public class CryptoUtils {
 	 * @return encrypted messsage. Can be null if error occurred.
 	 * @throws InvalidKeyException
 	 */
-	private byte[] rsaEncryptForRecipient(byte[] message,
+	byte[] rsaEncryptForRecipient(byte[] message,
 			QblEncPublicKey reciPubKey) throws InvalidKeyException {
 		byte[] cipherText = null;
 		try {

--- a/src/main/java/de/qabel/core/crypto/CryptoUtils.java
+++ b/src/main/java/de/qabel/core/crypto/CryptoUtils.java
@@ -462,6 +462,8 @@ public class CryptoUtils {
 	 * encrypted with a random AES key. The AES key gets RSA encrypted with the
 	 * recipients public key. The cipher text gets signed.
 	 * 
+	 * This function is deprecated. Use an AbstractBinaryDropMessage instead.
+	 * 
 	 * @param message
 	 *            String message to encrypt
 	 * @param recipient
@@ -472,6 +474,7 @@ public class CryptoUtils {
 	 * @return hybrid encrypted String message
 	 * @throws InvalidKeyException
 	 */
+	@Deprecated
 	public byte[] encryptHybridAndSign(String message,
 			QblEncPublicKey recipient, QblSignKeyPair signatureKey)
 			throws InvalidKeyException {
@@ -496,6 +499,8 @@ public class CryptoUtils {
 	 * using the own private key. The decrypted AES key is used to decrypt the
 	 * String message
 	 * 
+	 * This function is deprecated. Use an AbstractBinaryDropMessage instead.
+	 * 
 	 * @param cipherText
 	 *            hybrid encrypted String message
 	 * @param privKey
@@ -506,6 +511,7 @@ public class CryptoUtils {
 	 *         signature is invalid
 	 * @throws InvalidKeyException
 	 */
+	@Deprecated
 	public String decryptHybridAndValidateSignature(
 			byte[] cipherText, QblPrimaryKeyPair privKey,
 			QblSignPublicKey signatureKey) throws InvalidKeyException {

--- a/src/main/java/de/qabel/core/crypto/CryptoUtils.java
+++ b/src/main/java/de/qabel/core/crypto/CryptoUtils.java
@@ -44,8 +44,8 @@ public class CryptoUtils {
 	private final static String SIGNATURE_ALGORITHM = "RSASSA-PSS";
 	private final static String RSA_CIPHER_ALGORITM = "RSA/ECB/OAEPWITHSHA1ANDMGF1PADDING";
 	private final static String HMAC_ALGORITHM = "HMac/" + "SHA512";
-	private final static int RSA_SIGNATURE_SIZE_BYTE = 256;
-	private final static String SYMM_KEY_ALGORITHM = "AES";
+	final static int RSA_SIGNATURE_SIZE_BYTE = 256;
+	final static String SYMM_KEY_ALGORITHM = "AES";
 	private final static String SYMM_TRANSFORMATION = "AES/CTR/NoPadding";
 	private final static String SYMM_GCM_TRANSFORMATION = "AES/GCM/NoPadding";
 	private final static int SYMM_GCM_READ_SIZE_BYTE = 4096; // Should be multiple of 4096 byte due to flash block size.
@@ -53,7 +53,7 @@ public class CryptoUtils {
 	final static int SYMM_NONCE_SIZE_BYTE = 12;
 	private final static int AES_KEY_SIZE_BYTE = 32;
 	private final static int AES_KEY_SIZE_BIT = AES_KEY_SIZE_BYTE * 8;
-	private final static int ENCRYPTED_AES_KEY_SIZE_BYTE = 256;
+	final static int ENCRYPTED_AES_KEY_SIZE_BYTE = 256;
 
 	private final static Logger logger = LogManager.getLogger(CryptoUtils.class
 			.getName());
@@ -259,7 +259,7 @@ public class CryptoUtils {
 	 * @return is signature valid
 	 * @throws InvalidKeyException
 	 */
-	private boolean validateSignature(byte[] message, byte[] signature,
+	boolean validateSignature(byte[] message, byte[] signature,
 			QblSignPublicKey signPublicKey) throws InvalidKeyException {
 		byte[] sha512Sum = getSHA512sum(message);
 		return rsaValidateSignature(sha512Sum, signature,
@@ -304,7 +304,7 @@ public class CryptoUtils {
 	 * @return decrypted ciphertext, or null if undecryptable
 	 * @throws InvalidKeyException
 	 */
-	private byte[] rsaDecrypt(byte[] cipherText, RSAPrivateKey privKey)
+	byte[] rsaDecrypt(byte[] cipherText, RSAPrivateKey privKey)
 			throws InvalidKeyException {
 		byte[] plaintext = null;
 		try {
@@ -456,7 +456,7 @@ public class CryptoUtils {
 		}
 		return plainText;
 	}
-
+	
 	/**
 	 * Hybrid encrypts a String message for a recipient. The String message is
 	 * encrypted with a random AES key. The AES key gets RSA encrypted with the
@@ -477,6 +477,8 @@ public class CryptoUtils {
 			throws InvalidKeyException {
 		ByteArrayOutputStream bs = new ByteArrayOutputStream();
 		SecretKey aesKey = keyGenerator.generateKey();
+		
+		// pad message
 
 		try {
 			bs.write(rsaEncryptForRecipient(aesKey.getEncoded(), recipient));

--- a/src/main/java/de/qabel/core/exceptions/QblVersionMismatchException.java
+++ b/src/main/java/de/qabel/core/exceptions/QblVersionMismatchException.java
@@ -1,0 +1,5 @@
+package de.qabel.core.exceptions;
+
+public class QblVersionMismatchException extends QblException {
+	private static final long serialVersionUID = 1897875575875205815L;
+}

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -5,6 +5,7 @@ import de.qabel.core.crypto.QblKeyFactory;
 import de.qabel.core.crypto.QblPrimaryKeyPair;
 import de.qabel.core.drop.*;
 import de.qabel.core.exceptions.QblDropInvalidURL;
+import de.qabel.core.exceptions.QblDropPayloadSizeException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +63,7 @@ public class MultiPartCryptoTest {
     }
 
     @Test
-    public void multiPartCryptoOnlyOneMessageTest() throws InterruptedException {
+    public void multiPartCryptoOnlyOneMessageTest() throws InterruptedException, QblDropPayloadSizeException {
 
         this.sendMessage();
 		this.sendUnwantedMessage();
@@ -82,7 +83,7 @@ public class MultiPartCryptoTest {
     }
 
     @Test
-    public void multiPartCryptoMultiMessageTest() throws InterruptedException {
+    public void multiPartCryptoMultiMessageTest() throws InterruptedException, QblDropPayloadSizeException {
 
 		this.sendUnwantedMessage();
         this.sendMessage();
@@ -159,7 +160,7 @@ public class MultiPartCryptoTest {
         dropController.setDropServers(servers);
     }
 
-    private void sendMessage() {
+    private void sendMessage() throws QblDropPayloadSizeException {
         DropMessage<TestObject> dm = new DropMessage<TestObject>();
         TestObject data = new TestObject();
         data.setStr("Test");
@@ -179,7 +180,7 @@ public class MultiPartCryptoTest {
         drop.sendAndForget(dm, dropController.getContacts().getContacts());
     }
 
-	private void sendUnwantedMessage() {
+	private void sendUnwantedMessage() throws QblDropPayloadSizeException {
 		DropMessage<UnwantedTestObject> dm = new DropMessage<UnwantedTestObject>();
 		UnwantedTestObject data = new UnwantedTestObject();
 		data.setStr("Test");

--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -81,7 +81,7 @@ public class DropHTTPTest {
 	public void postMessageTooBig() {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
-		char[] chars = new char[2001];
+		char[] chars = new char[3000];
 		Arrays.fill(chars, 'a');
 		// When
 		int responseCode = dHTTP.send(this.workingUrl,


### PR DESCRIPTION
This implements
* a basic binary drop message handling API
* handling of binary drop message in the current version (0)

EDIT:
Implements message padding and closes #251 
Also implements a transport message handling thus closes #61 

Depends on Qabel/qabel-drop#14 to update the maximum drop message size on the drop server.