### PR TITLE
Remove checkout of a specific qabel-storage branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
  - cd ..
  - git clone https://github.com/Qabel/qabel-storage.git
  - cd qabel-storage
- - git checkout -b protocol_update origin/protocol_update
  - npm install
  - mkdir data
  - node app.js &


### PR DESCRIPTION
Removes the checkout of the protocol_update branch, because the master branch is up-to-date.