### PR TITLE
Hotfix: Increased size of too-big-drop-message

### DIFF
--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -81,7 +81,7 @@ public class DropHTTPTest {
 	public void postMessageTooBig() {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
-		char[] chars = new char[2001];
+		char[] chars = new char[3000];
 		Arrays.fill(chars, 'a');
 		// When
 		int responseCode = dHTTP.send(this.workingUrl,


### PR DESCRIPTION
Solves current test failure of test postMessageTooBig.

Cherry picked from #258 to be faster reviewable ;-)
Not needed if #258 got merged first. 