### PR TITLE
Make DropCallback public

### DIFF
--- a/src/main/java/de/qabel/core/drop/DropCallback.java
+++ b/src/main/java/de/qabel/core/drop/DropCallback.java
@@ -1,5 +1,5 @@
 package de.qabel.core.drop;
 
-interface DropCallback<T extends ModelObject> {
+public interface DropCallback<T extends ModelObject> {
 	void onDropMessage(DropMessage<T> message);
 }


### PR DESCRIPTION
 Make DropCallback public because it must be passed via the public DropController.register() method.