### PR TITLE
Implements a static getter to get the default ModuleManager.

### DIFF
--- a/src/main/java/de/qabel/core/module/ModuleManager.java
+++ b/src/main/java/de/qabel/core/module/ModuleManager.java
@@ -15,6 +15,9 @@ import de.qabel.core.config.Settings;
 import de.qabel.core.drop.DropController;
 
 public class ModuleManager {
+
+	private static ModuleManager defaultModuleManager = null;
+
 	static public class ClassLoader extends URLClassLoader{
 	    public ClassLoader() {
 	        super(new URL[0]);
@@ -24,6 +27,17 @@ public class ModuleManager {
 	    public void addURL(URL url) {
 	        super.addURL(url);
 	    }
+	}
+
+	/**
+	 * Get default ModuleManager. Creates a new one if none exists.
+	 * @return Default ModuleManager
+	 */
+	public static ModuleManager getDefault() {
+		if (defaultModuleManager == null) {
+			defaultModuleManager = new ModuleManager();
+		}
+		return defaultModuleManager;
 	}
 
 	public final static ClassLoader LOADER = new ClassLoader();


### PR DESCRIPTION
Does not prevent multiple `ModuleManagers`s, which are still needed for our tests.
We decided this in the meeting.

See #278 for more info.
If the ticket can be closed, tell me. 