### PR TITLE
Modular drop id generation

### DIFF
--- a/src/main/java/de/qabel/core/drop/AdjustableDropIdGenerator.java
+++ b/src/main/java/de/qabel/core/drop/AdjustableDropIdGenerator.java
@@ -15,7 +15,7 @@ import java.util.Random;
  * and therefore less anonymity but more performance.
  */
 public class AdjustableDropIdGenerator extends DropIdGenerator {
-	private int usedBits;
+	private final int usedBits;
 
 	/**
 	 * Creates a new random drop id using the whole id namespace.

--- a/src/main/java/de/qabel/core/drop/AdjustableDropIdGenerator.java
+++ b/src/main/java/de/qabel/core/drop/AdjustableDropIdGenerator.java
@@ -30,7 +30,8 @@ public class AdjustableDropIdGenerator extends DropIdGenerator {
 	 * for the namespace.
 	 * Hence, the collision probability is 1/2^(usedBits).
 	 *
-	 * @param usedBits number of bits used during randomization.
+	 * @param usedBits number of bits used during randomization. Must be in the
+	 *            interval (0, DROP_ID_LENGTH_BYTE*8].
 	 */
 	public AdjustableDropIdGenerator(int usedBits) {
 		if (usedBits <= 0 || usedBits > DROP_ID_LENGTH_BYTE * 8) {

--- a/src/main/java/de/qabel/core/drop/AdjustableDropIdGenerator.java
+++ b/src/main/java/de/qabel/core/drop/AdjustableDropIdGenerator.java
@@ -1,0 +1,63 @@
+package de.qabel.core.drop;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+/**
+ * This drop id generator generates drop ids randomly.
+ * It is called adjustable because one can adjust how many bits
+ * of the theoretically available id bit length is used during
+ * the randomization.
+ * This allows a simple tradeoff between collision probability
+ * and communication overhead or in other words between anonymity
+ * and performance.
+ * The rule of thumb is: more utilized bits less collision probability
+ * and therefore less anonymity but more performance.
+ */
+public class AdjustableDropIdGenerator extends DropIdGenerator {
+	private int usedBits;
+
+	/**
+	 * Creates a new random drop id using the whole id namespace.
+	 * Hence, the collision probability is 1/2^(DROP_ID_LENGTH_BYTE*8)
+	 */
+	public AdjustableDropIdGenerator() {
+		this(DROP_ID_LENGTH_BYTE*8);
+	}
+
+	/**
+	 * Creates a new random drop id using {@code usedBits} number of bits
+	 * for the namespace.
+	 * Hence, the collision probability is 1/2^(usedBits).
+	 *
+	 * @param usedBits number of bits used during randomization.
+	 */
+	public AdjustableDropIdGenerator(int usedBits) {
+		if (usedBits <= 0 || usedBits > DROP_ID_LENGTH_BYTE * 8) {
+			throw new IllegalArgumentException("Used bits must be between 0 and " + DROP_ID_LENGTH_BYTE);
+		}
+		this.usedBits = usedBits;
+	}
+
+	/**
+	 * Generate a random BigInteger smaller than given n.
+	 * 
+	 * @param n Upper bound of random number range.
+	 * @return Randomized BigInteger
+	 */
+	private static BigInteger nextRandomBigInteger(BigInteger n) {
+		Random rand = new Random();
+		BigInteger result;
+		do {
+			result = new BigInteger(n.bitLength(), rand);
+		} while (result.compareTo(n) >= 0);
+		return result;
+	}
+
+	@Override
+	byte[] generateDropIdBytes() {
+		BigInteger upperBoundary = BigInteger.valueOf(2).pow(usedBits);
+		return nextRandomBigInteger(upperBoundary).toByteArray();
+	}
+
+}

--- a/src/main/java/de/qabel/core/drop/DropIdGenerator.java
+++ b/src/main/java/de/qabel/core/drop/DropIdGenerator.java
@@ -1,0 +1,25 @@
+package de.qabel.core.drop;
+
+import java.util.Arrays;
+
+import org.bouncycastle.util.encoders.UrlBase64;
+
+public abstract class DropIdGenerator {
+	public static final int DROP_ID_LENGTH = 43;
+	public static final int DROP_ID_LENGTH_BYTE = 32;
+
+	public static DropIdGenerator getDefaultDropIdGenerator() {
+		return new AdjustableDropIdGenerator();
+	}
+
+	abstract byte[] generateDropIdBytes(); 
+
+	/**
+	 * Generates identifier for a drop encoded in Base64url.
+	 * @return the identifier
+	 */
+	public String generateDropId() {
+		byte[] id = Arrays.copyOf(this.generateDropIdBytes(), DROP_ID_LENGTH_BYTE); 
+		return new String(UrlBase64.encode(id)).substring(0, DROP_ID_LENGTH); // cut off terminating dot
+	}
+}

--- a/src/main/java/de/qabel/core/drop/DropIdGenerator.java
+++ b/src/main/java/de/qabel/core/drop/DropIdGenerator.java
@@ -5,8 +5,15 @@ import java.util.Arrays;
 import org.bouncycastle.util.encoders.UrlBase64;
 
 public abstract class DropIdGenerator {
-	public static final int DROP_ID_LENGTH = 43;
+	/**
+	 * Length of the drop id in base64 encoding.
+	 */
 	public static final int DROP_ID_LENGTH_BYTE = 32;
+	/**
+	 * Length of the base64url encoded id.
+	 * The terminating padding character is not part of the id. 
+	 */
+	public static final int DROP_ID_LENGTH = 4 * ((DROP_ID_LENGTH_BYTE + 2) / 3) - 1;
 
 	public static DropIdGenerator getDefaultDropIdGenerator() {
 		return new AdjustableDropIdGenerator();

--- a/src/main/java/de/qabel/core/drop/DropURL.java
+++ b/src/main/java/de/qabel/core/drop/DropURL.java
@@ -3,6 +3,8 @@ package de.qabel.core.drop;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.util.encoders.DecoderException;
 import org.bouncycastle.util.encoders.UrlBase64;
 
@@ -13,6 +15,7 @@ import de.qabel.core.exceptions.QblDropInvalidURL;
  * Class DropURL represents a URL fully identifying a drop.
  */
 public class DropURL {
+	private final static Logger logger = LogManager.getLogger(DropURL.class.getName());
 	
 	private URL url;
 
@@ -51,8 +54,9 @@ public class DropURL {
 		try {
 			this.url = new URL(server.getUrl().toString() + "/" + dropId);
 		} catch (MalformedURLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			logger.error("Failed to create drop url.", e);
+			// should not happen - cannot recover from this
+			throw new RuntimeException("Failed to create drop url.", e);
 		}
 	}
 	

--- a/src/main/java/de/qabel/core/drop/DropURL.java
+++ b/src/main/java/de/qabel/core/drop/DropURL.java
@@ -2,7 +2,6 @@ package de.qabel.core.drop;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 
 import org.bouncycastle.util.encoders.DecoderException;
 import org.bouncycastle.util.encoders.UrlBase64;
@@ -14,8 +13,6 @@ import de.qabel.core.exceptions.QblDropInvalidURL;
  * Class DropURL represents a URL fully identifying a drop.
  */
 public class DropURL {
-	private static final int DROP_ID_LENGTH = 43;
-	private static final int DROP_ID_LENGTH_BYTE = 32;
 	
 	private URL url;
 
@@ -33,11 +30,23 @@ public class DropURL {
 	
 	/**
 	 * Constructs a new drop url for a drop on the given drop server.
+	 * This uses the default drop id generator.
 	 * 
 	 * @param server Hosting drop server
+	 * @see DropIdGenerator
 	 */
 	public DropURL(DropServer server) {
-		String dropId = this.generateDropId();
+		this(server, DropIdGenerator.getDefaultDropIdGenerator());
+	}
+
+	/**
+	 * Constructs a new drop url for a drop on the given drop server.
+	 *
+	 * @param server Hosting drop server.
+	 * @param generator Generator used for drop id generation.
+	 */
+	public DropURL(DropServer server, DropIdGenerator generator) {
+		String dropId = generator.generateDropId();
 		
 		try {
 			this.url = new URL(server.getUrl().toString() + "/" + dropId);
@@ -47,17 +56,6 @@ public class DropURL {
 		}
 	}
 	
-	/**
-	 * Generates identifier for a drop encoded in Base64url.
-	 * @return the identifier
-	 */
-	private String generateDropId() {
-		// TODO this is just a dummy generator
-		byte[] id = new byte[DROP_ID_LENGTH_BYTE];
-		Arrays.fill(id, (byte)42);
-		return new String(UrlBase64.encode(id)).substring(0, DROP_ID_LENGTH); // cut off terminating dot
-	}
-
 	/**
 	 * Gets drop id part of drop url.
 	 * @return the drop id
@@ -75,7 +73,7 @@ public class DropURL {
 		// check if its a valid Drop-URL.
 		String dropID = this.getDropId();
 		
-		if (dropID.length() != DROP_ID_LENGTH) {
+		if (dropID.length() != DropIdGenerator.DROP_ID_LENGTH) {
 			throw new QblDropInvalidURL();
 		}
 		

--- a/src/test/java/de/qabel/core/drop/DropIdGenerationTest.java
+++ b/src/test/java/de/qabel/core/drop/DropIdGenerationTest.java
@@ -10,7 +10,7 @@ public class DropIdGenerationTest {
 	public ExpectedException exception = ExpectedException.none();
 
 	@Test
-	public void testAdustable() {
+	public void testAdjustable() {
 		DropIdGenerator generator = new AdjustableDropIdGenerator();
 		String id = generator.generateDropId();
 		Assert.assertEquals(DropIdGenerator.DROP_ID_LENGTH, id.length());

--- a/src/test/java/de/qabel/core/drop/DropIdGenerationTest.java
+++ b/src/test/java/de/qabel/core/drop/DropIdGenerationTest.java
@@ -1,0 +1,50 @@
+package de.qabel.core.drop;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DropIdGenerationTest {
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testAdustable() {
+		DropIdGenerator generator = new AdjustableDropIdGenerator();
+		String id = generator.generateDropId();
+		Assert.assertEquals(DropIdGenerator.DROP_ID_LENGTH, id.length());
+	}
+
+	@Test
+	public void testAdjustableTooFewBits() {
+		exception.expect(IllegalArgumentException.class);
+		DropIdGenerator generator = new AdjustableDropIdGenerator(0);
+		String id = generator.generateDropId();
+		Assert.assertEquals(DropIdGenerator.DROP_ID_LENGTH, id.length());
+	}
+
+	@Test
+	public void testAdjustableTooManyBits() {
+		exception.expect(IllegalArgumentException.class);
+		DropIdGenerator generator = new AdjustableDropIdGenerator(
+				DropIdGenerator.DROP_ID_LENGTH_BYTE * 8 + 1);
+		String id = generator.generateDropId();
+		Assert.assertEquals(DropIdGenerator.DROP_ID_LENGTH, id.length());
+	}
+
+	@Test
+	public void testAdjustableJustRightLow() {
+		DropIdGenerator generator = new AdjustableDropIdGenerator(1);
+		String id = generator.generateDropId();
+		Assert.assertEquals(DropIdGenerator.DROP_ID_LENGTH, id.length());
+	}
+
+	@Test
+	public void testAdjustableJustRightHigh() {
+		DropIdGenerator generator = new AdjustableDropIdGenerator(
+				DropIdGenerator.DROP_ID_LENGTH_BYTE * 8);
+		String id = generator.generateDropId();
+		Assert.assertEquals(DropIdGenerator.DROP_ID_LENGTH, id.length());
+	}
+}


### PR DESCRIPTION
I implemented a modular drop id generation.
* DropIdGenerator is an abstract drop id generator. Defines API.
* AdjustableDropIdGenerator is a simple randomizing drop id generator as proposed in [drop id choosing discussion](https://github.com/Qabel/qabel-doc/issues/16#issuecomment-52052136)

I think the AdjustableDropIdGenerator is a good placeholder until we come up with something better.
Well it's definitely better than the current fixed dummy id.