### PR TITLE
Fix erroneous escalation of invalid binary drop messages

### DIFF
--- a/src/main/java/de/qabel/core/crypto/AbstractBinaryDropMessage.java
+++ b/src/main/java/de/qabel/core/crypto/AbstractBinaryDropMessage.java
@@ -13,6 +13,7 @@ import de.qabel.core.config.Contact;
 import de.qabel.core.drop.DropDeserializer;
 import de.qabel.core.drop.DropMessage;
 import de.qabel.core.drop.DropSerializer;
+import de.qabel.core.exceptions.QblDropInvalidMessageSizeException;
 import de.qabel.core.exceptions.QblDropPayloadSizeException;
 import de.qabel.core.exceptions.QblVersionMismatchException;
 
@@ -33,12 +34,19 @@ public abstract class AbstractBinaryDropMessage {
 		}
 	}
 
+	/**
+	 * Creates binary drop message from the raw binary plaintext.
+	 *
+	 * @param binaryMessage raw binary plaintext.
+	 * @throws QblVersionMismatchException if the version header byte is not as expected.
+	 * @throws QblDropInvalidMessageSizeException if size does not match the version requirement.
+	 */
 	public AbstractBinaryDropMessage(byte[] binaryMessage)
-			throws QblVersionMismatchException {
+			throws QblVersionMismatchException, QblDropInvalidMessageSizeException {
 		if (binaryMessage.length != getTotalSize()) {
-			logger.error("Unexpected message size. Is: " + binaryMessage.length
+			logger.debug("Unexpected message size. Is: " + binaryMessage.length
 					+ " Should: " + getTotalSize());
-			throw new QblVersionMismatchException();
+			throw new QblDropInvalidMessageSizeException();
 		}
 		if (binaryMessage[0] != getVersion()) {
 			throw new QblVersionMismatchException();

--- a/src/main/java/de/qabel/core/crypto/BinaryDropMessageV0.java
+++ b/src/main/java/de/qabel/core/crypto/BinaryDropMessageV0.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 
 import de.qabel.core.config.Contact;
 import de.qabel.core.drop.DropMessage;
+import de.qabel.core.exceptions.QblDropInvalidMessageSizeException;
 import de.qabel.core.exceptions.QblDropPayloadSizeException;
 import de.qabel.core.exceptions.QblVersionMismatchException;
 
@@ -33,7 +34,7 @@ public class BinaryDropMessageV0 extends AbstractBinaryDropMessage {
 	}
 
 	public BinaryDropMessageV0(byte[] binaryMessage)
-			throws QblVersionMismatchException {
+			throws QblVersionMismatchException, QblDropInvalidMessageSizeException {
 		super(binaryMessage);
 		encKey = Arrays.copyOfRange(binaryMessage, HEADER_SIZE, HEADER_SIZE
 				+ CryptoUtils.ENCRYPTED_AES_KEY_SIZE_BYTE);

--- a/src/main/java/de/qabel/core/drop/DropController.java
+++ b/src/main/java/de/qabel/core/drop/DropController.java
@@ -12,6 +12,7 @@ import de.qabel.core.config.Contacts;
 import de.qabel.core.config.DropServer;
 import de.qabel.core.config.DropServers;
 import de.qabel.core.crypto.*;
+import de.qabel.core.exceptions.QblDropInvalidMessageSizeException;
 import de.qabel.core.exceptions.QblDropPayloadSizeException;
 import de.qabel.core.exceptions.QblVersionMismatchException;
 import de.qabel.core.http.DropHTTP;
@@ -218,6 +219,11 @@ public class DropController {
 				} catch (QblVersionMismatchException e) {
 					logger.error("Version mismatch in binary drop message", e);
 					throw new RuntimeException("Version mismatch should not happen", e);
+				} catch (QblDropInvalidMessageSizeException e) {
+					logger.info("Binary drop message version 0 with unexpected size discarded.");
+					// Invalid message uploads may happen with malicious intent
+					// or by broken clients. Skip.
+					continue;
 				}
 				break;
 			default:

--- a/src/main/java/de/qabel/core/exceptions/QblDropInvalidMessageSizeException.java
+++ b/src/main/java/de/qabel/core/exceptions/QblDropInvalidMessageSizeException.java
@@ -1,0 +1,5 @@
+package de.qabel.core.exceptions;
+
+public class QblDropInvalidMessageSizeException extends QblException {
+	private static final long serialVersionUID = -5790122045895287425L;
+}


### PR DESCRIPTION
It is not unlikely that binary drop messages are received that have the wrong
size compared to expectation implied by the header version byte.
This may for instance happen, if someone maliciously uploads invalid messages or
simply due to broken clients.

This patch fixes the handling of this such unexpected sizes.
They are no longer escalated to a RuntimeException (as was a bug), but are now
logged and then skipped.
Therefore, a new exception class is introduced to distinguish this size
mismatches from other critical version mismatches.