### PR TITLE
DropHTTP with HTTPResult

### DIFF
--- a/src/main/java/de/qabel/core/drop/DropController.java
+++ b/src/main/java/de/qabel/core/drop/DropController.java
@@ -15,7 +15,7 @@ import de.qabel.core.crypto.*;
 import de.qabel.core.exceptions.QblDropPayloadSizeException;
 import de.qabel.core.exceptions.QblVersionMismatchException;
 import de.qabel.core.http.DropHTTP;
-
+import de.qabel.core.http.HTTPResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -186,7 +186,8 @@ public class DropController {
 
 		BinaryDropMessageV0 binaryMessage = new BinaryDropMessageV0(message);
 		for (DropURL u : contact.getDropUrls()) {
-			result.addErrorCode(http.send(u.getUrl(), binaryMessage.assembleMessageFor(contact)));
+			HTTPResult<?> dropResult = http.send(u.getUrl(), binaryMessage.assembleMessageFor(contact));
+			result.addErrorCode(dropResult.getResponseCode());
 		}
 		
 		return result;

--- a/src/main/java/de/qabel/core/drop/DropController.java
+++ b/src/main/java/de/qabel/core/drop/DropController.java
@@ -202,13 +202,13 @@ public class DropController {
 	 */
 	public Collection<DropMessage<?>> retrieve(URL url, Collection<Contact> contacts) {
 		DropHTTP http = new DropHTTP();
-		Collection<byte[]> cipherMessages = http.receiveMessages(url);
+		HTTPResult<Collection<byte[]>> cipherMessages = http.receiveMessages(url);
 		Collection<DropMessage<?>> plainMessages = new ArrayList<>();
 
 		List<Contact> ccc = new ArrayList<Contact>(contacts);
 		Collections.shuffle(ccc, new SecureRandom());
 
-		for (byte[] cipherMessage : cipherMessages) {
+		for (byte[] cipherMessage : cipherMessages.getData()) {
 			AbstractBinaryDropMessage binMessage;
 			byte binaryFormatVersion = cipherMessage[0];
 			

--- a/src/main/java/de/qabel/core/http/DropHTTP.java
+++ b/src/main/java/de/qabel/core/http/DropHTTP.java
@@ -45,19 +45,20 @@ public class DropHTTP {
 		return result;
 	}
 
-	public Collection<byte[]> receiveMessages(URL url) {
+	public HTTPResult<Collection<byte[]>> receiveMessages(URL url) {
 		return this.receiveMessages(url, 0);
 	}
 
-	public Collection<byte[]> receiveMessages(URL url, long sinceDate) {
-		int responseCode = 0;
+	public HTTPResult<Collection<byte[]>> receiveMessages(URL url, long sinceDate) {
+		HTTPResult<Collection<byte[]>> result = new HTTPResult<>();
 		HttpURLConnection conn = (HttpURLConnection) this.setupConnection(url);
 		conn.setIfModifiedSince(sinceDate);
 		Collection<byte[]> messages = new ArrayList<byte[]>();
 		try {
 			conn.setRequestMethod("GET");
-			responseCode = conn.getResponseCode();
-			if (responseCode == 200) {
+			result.setResponseCode(conn.getResponseCode());
+			result.setOk(conn.getResponseCode() == 200);
+			if (result.isOk()) {
 				InputStream inputstream = conn.getInputStream();
 				MimeTokenStream stream = new MimeTokenStream();
 				stream.parseHeadless(inputstream, conn.getContentType());
@@ -77,7 +78,8 @@ public class DropHTTP {
 		} finally {
 			conn.disconnect();
 		}
-		return messages;
+		result.setData(messages);
+		return result;
 	}
 
 	public int head(URL url) {

--- a/src/main/java/de/qabel/core/http/DropHTTP.java
+++ b/src/main/java/de/qabel/core/http/DropHTTP.java
@@ -82,24 +82,25 @@ public class DropHTTP {
 		return result;
 	}
 
-	public int head(URL url) {
+	public HTTPResult<?> head(URL url) {
 		return this.head(url, 0);
 	}
 
-	public int head(URL url, long sinceDate) {
-		int responseCode = 0;
+	public HTTPResult<?> head(URL url, long sinceDate) {
+		HTTPResult<?> result = new HTTPResult<>();
 		HttpURLConnection conn = (HttpURLConnection) this.setupConnection(url);
 		conn.setIfModifiedSince(sinceDate);
 		try {
 			conn.setRequestMethod("GET");
-			responseCode = conn.getResponseCode();
+			result.setResponseCode(conn.getResponseCode());
+			result.setOk(conn.getResponseCode() == 200);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 			conn.disconnect();
 		}
-		return responseCode;
+		return result;
 	}
 
 	private URLConnection setupConnection(URL url) {

--- a/src/main/java/de/qabel/core/http/DropHTTP.java
+++ b/src/main/java/de/qabel/core/http/DropHTTP.java
@@ -19,8 +19,8 @@ public class DropHTTP {
 
 	String dateFormat;
 
-	public int send(URL url, byte[] message) {
-		int responseCode = 0;
+	public HTTPResult<?> send(URL url, byte[] message) {
+		HTTPResult<?> result = new HTTPResult<>();
 		HttpURLConnection conn = (HttpURLConnection) this.setupConnection(url);
 		conn.setDoOutput(true); // indicates POST method
 		conn.setDoInput(true);
@@ -33,7 +33,8 @@ public class DropHTTP {
 			out.write(message);
 			out.flush();
 			out.close();
-			responseCode = conn.getResponseCode();
+			result.setResponseCode(conn.getResponseCode());
+			result.setOk(conn.getResponseCode() == 200);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -41,7 +42,7 @@ public class DropHTTP {
 			conn.disconnect();
 
 		}
-		return responseCode;
+		return result;
 	}
 
 	public Collection<byte[]> receiveMessages(URL url) {

--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -100,10 +100,12 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		Collection<byte[]> response = dHTTP.receiveMessages(this.workingUrl);
+		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.workingUrl);
 		// Then
-		assertNotEquals(null, response);
-		assertNotEquals(new ArrayList<String>(), response);
+		assertNotEquals(null, result.getData());
+		assertNotEquals(new ArrayList<String>(), result.getData());
+		assertTrue(result.isOk());
+		assertEquals(200, result.getResponseCode());
 	}
 
 	// GET 400
@@ -112,10 +114,12 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		Collection<byte[]> response = dHTTP.receiveMessages(this.tooShortUrl);
+		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.tooShortUrl);
 		// Then
-		assertNotEquals(null, response);
-		assertEquals(new ArrayList<String>(), response);
+		assertNotEquals(null, result.getData());
+		assertEquals(new ArrayList<String>(), result.getData());
+		assertFalse(result.isOk());
+		assertEquals(400, result.getResponseCode());
 	}
 
 	// GET 204
@@ -124,10 +128,12 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		Collection<byte[]> response = dHTTP.receiveMessages(this.notExistingUrl);
+		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.notExistingUrl);
 		// Then
-		assertNotEquals(null, response);
-		assertEquals(new ArrayList<String>(), response);
+		assertNotEquals(null, result.getData());
+		assertEquals(new ArrayList<String>(), result.getData());
+		assertFalse(result.isOk());
+		assertEquals(204, result.getResponseCode());
 	}
 
 	// GET 200 SINCE
@@ -136,10 +142,12 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		Collection<byte[]> response = dHTTP.receiveMessages(this.shouldContainMessagesUrl, 0);
+		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.shouldContainMessagesUrl, 0);
 		// Then
-		assertNotEquals(null, response);
-		assertNotEquals(new ArrayList<String>(), response);
+		assertNotEquals(null, result.getData());
+		assertNotEquals(new ArrayList<String>(), result.getData());
+		assertTrue(result.isOk());
+		assertEquals(200, result.getResponseCode());
 	}
 
 	// GET 304 SINCE
@@ -148,11 +156,13 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		Collection<byte[]> response = dHTTP.receiveMessages(this.workingUrl,
+		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.workingUrl,
 				System.currentTimeMillis());
 		// Then
-		assertNotEquals(null, response);
-		assertEquals(new ArrayList<String>(), response);
+		assertNotEquals(null, result.getData());
+		assertEquals(new ArrayList<String>(), result.getData());
+		assertFalse(result.isOk());
+		assertEquals(304, result.getResponseCode());
 	}
 
 	// GET 204 SINCE
@@ -161,11 +171,13 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		Collection<byte[]> response = dHTTP.receiveMessages(this.notExistingUrl,
+		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.notExistingUrl,
 				System.currentTimeMillis());
 		// Then
-		assertNotEquals(null, response);
-		assertEquals(new ArrayList<String>(), response);
+		assertNotEquals(null, result.getData());
+		assertEquals(new ArrayList<String>(), result.getData());
+		assertFalse(result.isOk());
+		assertEquals(204, result.getResponseCode());
 	}
 
 	// HEAD 200

--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -1,6 +1,8 @@
 package de.qabel.core.http;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
 import java.net.MalformedURLException;
@@ -10,7 +12,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class DropHTTPTest {
@@ -58,10 +59,11 @@ public class DropHTTPTest {
 		DropHTTP dHTTP = new DropHTTP();
 		String message = "Test";
 		// When
-		int responseCode = dHTTP.send(this.workingUrl, message.getBytes());
+		HTTPResult<?> result = dHTTP.send(this.workingUrl, message.getBytes());
 		this.postedAt = System.currentTimeMillis();
 		// Then
-		assertEquals(200, responseCode);
+		assertEquals(200, result.getResponseCode());
+		assertTrue(result.isOk());
 	}
 
 	// POST 400
@@ -71,9 +73,10 @@ public class DropHTTPTest {
 		DropHTTP dHTTP = new DropHTTP();
 		String message = "";
 		// When
-		int responseCode = dHTTP.send(this.workingUrl, message.getBytes());
+		HTTPResult<?> result = dHTTP.send(this.workingUrl, message.getBytes());
 		// Then
-		assertEquals(400, responseCode);
+		assertEquals(400, result.getResponseCode());
+		assertFalse(result.isOk());
 	}
 
 	// POST 413
@@ -84,10 +87,11 @@ public class DropHTTPTest {
 		char[] chars = new char[2574]; // one byte more than the server accepts
 		Arrays.fill(chars, 'a');
 		// When
-		int responseCode = dHTTP.send(this.workingUrl,
+		HTTPResult<?> result = dHTTP.send(this.workingUrl,
 				new String(chars).getBytes());
 		// Then
-		assertEquals(413, responseCode);
+		assertEquals(413, result.getResponseCode());
+		assertFalse(result.isOk());
 	}
 
 	// GET 200

--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -103,7 +103,7 @@ public class DropHTTPTest {
 		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.workingUrl);
 		// Then
 		assertNotEquals(null, result.getData());
-		assertNotEquals(new ArrayList<String>(), result.getData());
+		assertNotEquals(new ArrayList<byte[]>(), result.getData());
 		assertTrue(result.isOk());
 		assertEquals(200, result.getResponseCode());
 	}
@@ -145,7 +145,7 @@ public class DropHTTPTest {
 		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.shouldContainMessagesUrl, 0);
 		// Then
 		assertNotEquals(null, result.getData());
-		assertNotEquals(new ArrayList<String>(), result.getData());
+		assertNotEquals(new ArrayList<byte[]>(), result.getData());
 		assertTrue(result.isOk());
 		assertEquals(200, result.getResponseCode());
 	}
@@ -186,9 +186,10 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		int responseCode = dHTTP.head(this.shouldContainMessagesUrl);
+		HTTPResult<?> result = dHTTP.head(this.shouldContainMessagesUrl);
 		// Then
-		assertEquals(200, responseCode);
+		assertEquals(200, result.getResponseCode());
+		assertTrue(result.isOk());
 	}
 
 	// HEAD 400
@@ -197,20 +198,22 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		int responseCode = dHTTP.head(this.tooShortUrl);
+		HTTPResult<?> result = dHTTP.head(this.tooShortUrl);
 		// Then
-		assertEquals(400, responseCode);
+		assertEquals(400, result.getResponseCode());
+		assertFalse(result.isOk());
 	}
 
-	// HEAD 404
+	// HEAD 204
 	@Test
 	public void shouldBeEmpty() {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		int responseCode = dHTTP.head(this.notExistingUrl);
+		HTTPResult<?> result = dHTTP.head(this.notExistingUrl);
 		// Then
-		assertEquals(204, responseCode);
+		assertEquals(204, result.getResponseCode());
+		assertFalse(result.isOk());
 	}
 
 	// HEAD 200 SINCE
@@ -219,9 +222,10 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		int responseCode = dHTTP.head(this.workingUrl, this.postedAt);
+		HTTPResult<?> result = dHTTP.head(this.workingUrl, this.postedAt);
 		// Then
-		assertEquals(200, responseCode);
+		assertEquals(200, result.getResponseCode());
+		assertTrue(result.isOk());
 	}
 
 	// HEAD 304 SINCE
@@ -230,10 +234,11 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		int responseCode = dHTTP.head(this.shouldContainNoNewMessagesSinceDateUrl,
+		HTTPResult<?> result = dHTTP.head(this.shouldContainNoNewMessagesSinceDateUrl,
 				System.currentTimeMillis());
 		// Then
-		assertEquals(304, responseCode);
+		assertEquals(304, result.getResponseCode());
+		assertFalse(result.isOk());
 	}
 
 	// HEAD 404 + SINCE
@@ -242,10 +247,11 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		int responseCode = dHTTP.head(this.notExistingUrl,
+		HTTPResult<?> result = dHTTP.head(this.notExistingUrl,
 				System.currentTimeMillis() + 10);
 		// Then
-		assertEquals(204, responseCode);
+		assertEquals(204, result.getResponseCode());
+		assertFalse(result.isOk());
 	}
 
 }

--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -117,7 +117,7 @@ public class DropHTTPTest {
 		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.tooShortUrl);
 		// Then
 		assertNotEquals(null, result.getData());
-		assertEquals(new ArrayList<String>(), result.getData());
+		assertEquals(new ArrayList<byte[]>(), result.getData());
 		assertFalse(result.isOk());
 		assertEquals(400, result.getResponseCode());
 	}
@@ -131,7 +131,7 @@ public class DropHTTPTest {
 		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.notExistingUrl);
 		// Then
 		assertNotEquals(null, result.getData());
-		assertEquals(new ArrayList<String>(), result.getData());
+		assertEquals(new ArrayList<byte[]>(), result.getData());
 		assertFalse(result.isOk());
 		assertEquals(204, result.getResponseCode());
 	}
@@ -160,7 +160,7 @@ public class DropHTTPTest {
 				System.currentTimeMillis());
 		// Then
 		assertNotEquals(null, result.getData());
-		assertEquals(new ArrayList<String>(), result.getData());
+		assertEquals(new ArrayList<byte[]>(), result.getData());
 		assertFalse(result.isOk());
 		assertEquals(304, result.getResponseCode());
 	}
@@ -175,7 +175,7 @@ public class DropHTTPTest {
 				System.currentTimeMillis());
 		// Then
 		assertNotEquals(null, result.getData());
-		assertEquals(new ArrayList<String>(), result.getData());
+		assertEquals(new ArrayList<byte[]>(), result.getData());
 		assertFalse(result.isOk());
 		assertEquals(204, result.getResponseCode());
 	}

--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -156,7 +156,7 @@ public class DropHTTPTest {
 		// Given
 		DropHTTP dHTTP = new DropHTTP();
 		// When
-		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.workingUrl,
+		HTTPResult<Collection<byte[]>> result = dHTTP.receiveMessages(this.shouldContainNoNewMessagesSinceDateUrl,
 				System.currentTimeMillis());
 		// Then
 		assertNotEquals(null, result.getData());


### PR DESCRIPTION
The DropHTTP returns HTTPResult for ```send```, ```receive``` and ```probe```. So they (especially ```receive```) return more information.