### PR TITLE
Added object persistence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.51'
 	compile group: 'org.apache.james', name: 'apache-mime4j', version: '0.7.2'
 	compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.+'
+	compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.8.7'
 	compile project(':ackack')
 }
 

--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -109,8 +109,8 @@ public class ContactsActor extends Actor {
 			break;
 		case REMOVE_CONTACTS:
 			for (int i = data.length-1; i>=0; i--) {
-				this.contacts.remove(data[i].toString());
 				persistence.removeEntity(contacts.getByKeyIdentifier(data[i].toString()).getPersistenceID(), Contact.class);
+				this.contacts.remove(data[i].toString());
 			}
 			break;
 		}

--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -17,9 +17,9 @@ public class ContactsActor extends Actor {
 	private Contacts contacts;
 	private Persistence persistence;
 
-	static ContactsActor getDefault(char[] password) {
+	static ContactsActor getDefault() {
 		if (defaultContactsActor == null) {
-			defaultContactsActor = new ContactsActor(password);
+			defaultContactsActor = new ContactsActor();
 		}
 		return defaultContactsActor;
 	}
@@ -28,13 +28,13 @@ public class ContactsActor extends Actor {
 	private static final String RETRIEVE_CONTACTS = "retrieveContacts";
 	private static final String REMOVE_CONTACTS = "removeContacts";
 
-	public ContactsActor (Contacts contacts, char[] password) {
+	public ContactsActor (Contacts contacts) {
 		this.contacts = contacts;
-		this.persistence = new SQLitePersistence(password);
+		this.persistence = new SQLitePersistence();
 	}
 
-	public ContactsActor (char[] password) {
-		this.persistence = new SQLitePersistence(password);
+	public ContactsActor () {
+		this.persistence = new SQLitePersistence();
 		this.contacts = new Contacts();
 		List a = persistence.getEntities(Contact.class);
 

--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -17,7 +17,7 @@ public class ContactsActor extends Actor {
 	private Contacts contacts;
 	private Persistence persistence;
 
-	static ContactsActor getDefault(String password) {
+	static ContactsActor getDefault(char[] password) {
 		if (defaultContactsActor == null) {
 			defaultContactsActor = new ContactsActor(password);
 		}
@@ -28,12 +28,12 @@ public class ContactsActor extends Actor {
 	private static final String RETRIEVE_CONTACTS = "retrieveContacts";
 	private static final String REMOVE_CONTACTS = "removeContacts";
 
-	public ContactsActor (Contacts contacts, String password) {
+	public ContactsActor (Contacts contacts, char[] password) {
 		this.contacts = contacts;
 		this.persistence = new SQLitePersistence(password);
 	}
 
-	public ContactsActor (String password) {
+	public ContactsActor (char[] password) {
 		this.persistence = new SQLitePersistence(password);
 		this.contacts = new Contacts();
 		List a = persistence.getEntities(Contact.class);

--- a/src/main/java/de/qabel/core/config/Entity.java
+++ b/src/main/java/de/qabel/core/config/Entity.java
@@ -1,10 +1,10 @@
 package de.qabel.core.config;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.drop.DropURL;
@@ -15,6 +15,9 @@ import de.qabel.core.drop.DropURL;
  */
 public abstract class Entity extends SyncSettingItem {
 	private static final long serialVersionUID = 570661846263644501L;
+	private static final Set<UUID> uuids = new HashSet<>();
+
+	private UUID persistenceID;
 	private final Set<DropURL> dropUrls;
 	private final Set<AbstractModuleSettings> moduleSettings = new HashSet<AbstractModuleSettings>(); // TODO: Will
 
@@ -24,6 +27,7 @@ public abstract class Entity extends SyncSettingItem {
 		} else {
 			this.dropUrls = new HashSet<>();
 		}
+		this.persistenceID = genPersistenceID();
 	}
 	
 	abstract public QblECPublicKey getEcPublicKey();
@@ -37,6 +41,8 @@ public abstract class Entity extends SyncSettingItem {
 		return this.getEcPublicKey().getReadableKeyIdentifier();
 	}
 
+	public String getPersistenceID() { return persistenceID.toString(); }
+
 	public Set<DropURL> getDropUrls() {
 		return Collections.unmodifiableSet(dropUrls);
 	}
@@ -47,6 +53,19 @@ public abstract class Entity extends SyncSettingItem {
 
 	public Set<AbstractModuleSettings> getModuleSettings() {
 		return moduleSettings;
+	}
+
+	/**
+	 * Generated a random UUID for persistent storage. It ensures that Entities are using a unique UUID.
+	 * @return Unique UUID
+	 */
+	private UUID genPersistenceID(){
+		UUID uuid = UUID.randomUUID();
+		while (uuids.contains(uuid)) {
+			uuid = UUID.randomUUID();
+		}
+		uuids.add(uuid);
+		return uuid;
 	}
 
 	@Override

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -48,7 +48,7 @@ public abstract class Persistence {
 	/**
 	 * Initializes the persistence class
 	 */
-	final void init(String password) {
+	final void init(char[] password) {
 		this.keyParameter = getMasterKey(deriveKey(password, getSalt(false)));
 		initCalled = true;
 	}
@@ -68,7 +68,7 @@ public abstract class Persistence {
 	 * @param newPassword New password
 	 * @return True if password has been changed
 	 */
-	final boolean changePassword(String oldPassword, String newPassword) {
+	final boolean changePassword(char[] oldPassword, char[] newPassword) {
 		return reEncryptMasterKey(deriveKey(oldPassword, getSalt(false)), deriveKey(newPassword, getSalt(true)));
 	}
 
@@ -144,12 +144,12 @@ public abstract class Persistence {
 	 * @param salt Salt for key derivation
 	 * @return Encryption key for serialization/deserialization
 	 */
-	private KeyParameter deriveKey(String password, byte[] salt) {
+	private KeyParameter deriveKey(char[] password, byte[] salt) {
 		SecretKey key;
 		try {
 			SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance(SECRET_KEY_ALGORITHM);
 			key = secretKeyFactory.generateSecret(
-					new PBEKeySpec(password.toCharArray(), salt,
+					new PBEKeySpec(password, salt,
 							PBKDF2_ROUNDS, AES_KEY_SIZE_BIT));
 			return new KeyParameter(key.getEncoded());
 		} catch (InvalidKeySpecException e) {

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -43,7 +43,10 @@ public abstract class Persistence<T> {
 			logger.fatal("Cannot find selected algorithm!", e);
 			throw new RuntimeException("Cannot find selected algorithm!", e);
 		}
-		connect(dbName);
+		if (!connect(dbName)) {
+			logger.fatal("Cannot connect to database!");
+			throw new RuntimeException("Cannot connect to database!");
+		}
 		this.keyParameter = getMasterKey(deriveKey(PASSWORD, getSalt(false)));
 	}
 

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -21,7 +21,7 @@ import java.util.List;
  * methods and a key derived from the provides password with PBKDF2 and a salt.
  *
  */
-public abstract class Persistence {
+public abstract class Persistence<T> {
 	private final static Logger logger = LogManager.getLogger(Persistence.class.getName());
 	private static final String SECRET_KEY_ALGORITHM = "PBKDF2WithHmacSHA1";
 	private static final int PBKDF2_ROUNDS = 65536;
@@ -35,7 +35,7 @@ public abstract class Persistence {
 	private SecretKeyFactory secretKeyFactory;
 	CryptoUtils cryptoutils;
 
-	public Persistence(String dbName) {
+	public Persistence(T dbName) {
 		this.cryptoutils = new CryptoUtils();
 		try {
 			this.secretKeyFactory = SecretKeyFactory.getInstance(SECRET_KEY_ALGORITHM);
@@ -73,7 +73,7 @@ public abstract class Persistence {
 	 * @param dbName Database name to connect to
 	 * @return Result of the operation
 	 */
-	abstract boolean connect(String dbName);
+	abstract boolean connect(T dbName);
 
 	/**
 	 * Create new or receive previously created salt.

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -35,7 +35,7 @@ public abstract class Persistence<T> {
 	private SecretKeyFactory secretKeyFactory;
 	CryptoUtils cryptoutils;
 
-	public Persistence(T dbName) {
+	public Persistence(T database) {
 		this.cryptoutils = new CryptoUtils();
 		try {
 			this.secretKeyFactory = SecretKeyFactory.getInstance(SECRET_KEY_ALGORITHM);
@@ -43,7 +43,7 @@ public abstract class Persistence<T> {
 			logger.fatal("Cannot find selected algorithm!", e);
 			throw new RuntimeException("Cannot find selected algorithm!", e);
 		}
-		if (!connect(dbName)) {
+		if (!connect(database)) {
 			logger.fatal("Cannot connect to database!");
 			throw new RuntimeException("Cannot connect to database!");
 		}
@@ -73,10 +73,10 @@ public abstract class Persistence<T> {
 
 	/**
 	 * Connect to the used database
-	 * @param dbName Database name to connect to
+	 * @param database Database name to connect to
 	 * @return Result of the operation
 	 */
-	abstract boolean connect(T dbName);
+	abstract boolean connect(T database);
 
 	/**
 	 * Create new or receive previously created salt.

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -1,0 +1,199 @@
+package de.qabel.core.config;
+
+import de.qabel.core.crypto.CryptoUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.io.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.List;
+
+/**
+ * Persistence defines methods to store encrypted entities into a database.
+ * Entities has to be Serializable.
+ * Serialized data is encrypted with AES256 GCM, a nonce provided to the serialize/deserialize
+ * methods and a key derived from the provides password with PBKDF2 and a salt.
+ *
+ * Inheritors of Persistence must call init() when a call of getSalt() is possible. Usually after a database
+ * connection is established.
+ */
+public abstract class Persistence {
+	private final static Logger logger = LogManager.getLogger(Persistence.class.getName());
+	private static final String SECRET_KEY_ALGORITHM = "PBKDF2WithHmacSHA1";
+	private static final int PBKDF2_ROUNDS = 65536;
+	private static final int AES_KEY_SIZE_BIT = 256;
+	static final int AES_KEY_SIZE_BYTE = AES_KEY_SIZE_BIT / 8;
+	static final int NONCE_SIZE_BYTE = 32;
+	static final int SALT_SIZE_BYTE = 32;
+
+	private boolean initCalled;
+	private KeyParameter keyParameter;
+	CryptoUtils cryptoutils;
+
+	/**
+	 * Inheritors of Persistence must call init() when a call of getSalt() is possible. Usually after a database
+	 * connection is established.
+	 */
+	public Persistence() {
+		this.cryptoutils = new CryptoUtils();
+		initCalled = false;
+	}
+
+	/**
+	 * Initializes the persistence class
+	 */
+	final void init(String password) {
+		this.keyParameter = getMasterKey(deriveKey(password, getSalt(false)));
+		initCalled = true;
+	}
+
+	/**
+	 * Checks if Persistence class has been initialized.
+	 */
+	private void checkInitCalled() {
+		if (!initCalled) {
+			throw new IllegalStateException("Inheritors of Persistence must call init() after establishing a connection!");
+		}
+	}
+
+	/**
+	 * Changes the encryption password by re-encrypting the master encryption key
+	 * @param oldPassword Old password
+	 * @param newPassword New password
+	 * @return True if password has been changed
+	 */
+	final boolean changePassword(String oldPassword, String newPassword) {
+		return reEncryptMasterKey(deriveKey(oldPassword, getSalt(false)), deriveKey(newPassword, getSalt(true)));
+	}
+
+	/**
+	 * Create new or receive previously created salt.
+	 * @return salt for key derivation
+	 */
+	abstract byte[] getSalt(boolean forceNewSalt);
+
+	/**
+	 * Create new or receive previously created master encryption key.
+	 * @return master encryption key
+	 */
+	abstract KeyParameter getMasterKey(KeyParameter encryptionKey);
+
+	/**
+	 * Re-encrypts the master key with a new encryption key
+	 * @param oldKey Old encryption key
+	 * @param newKey New encryption key
+	 * @return True if master key has been re-encrypted
+	 */
+	abstract boolean reEncryptMasterKey(KeyParameter oldKey, KeyParameter newKey);
+
+	/**
+	 * Persists an entity
+	 * @param id ID for entity storage
+	 * @param object Entity to persist
+	 * @return Result of the operation
+	 */
+	abstract boolean persistEntity(String id, Serializable object);
+
+	/**
+	 * Updated a previously stored entity
+	 * @param id ID of the stored entity
+	 * @param object Entity to replace stored entity with
+	 * @return Result of the operation
+	 */
+	abstract boolean updateEntity(String id, Serializable object);
+
+	/**
+	 * Removes a persisted entity
+	 * @param id ID of persisted entity
+	 * @param cls Class of persisted entity
+	 * @return Result of the operation
+	 */
+	abstract boolean removeEntity(String id, Class cls);
+
+	/**
+	 * Get an entity
+	 * @param id ID of the stored entity
+	 * @param cls Class of the entity to reveice
+	 * @return Stored entity
+	 */
+	abstract Object getEntity(String id, Class cls);
+
+	/**
+	 * Get all entities of the provides Class
+	 * @param cls Class to get all stored entities for
+	 * @return List of stored entities
+	 */
+	abstract List<Object> getEntities(Class cls);
+
+	/**
+	 * Drops the table for the provided Class
+	 * @param cls Class to drop table for
+	 * @return Result of the operation
+	 */
+	abstract boolean dropTable(Class cls);
+
+	/**
+	 * Derives the encryption key from the password and a salt.
+ 	 * @param password Password for key derivation
+	 * @param salt Salt for key derivation
+	 * @return Encryption key for serialization/deserialization
+	 */
+	private KeyParameter deriveKey(String password, byte[] salt) {
+		SecretKey key;
+		try {
+			SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance(SECRET_KEY_ALGORITHM);
+			key = secretKeyFactory.generateSecret(
+					new PBEKeySpec(password.toCharArray(), salt,
+							PBKDF2_ROUNDS, AES_KEY_SIZE_BIT));
+			return new KeyParameter(key.getEncoded());
+		} catch (InvalidKeySpecException e) {
+			logger.error("Invalid KeySpec!", e);
+			return null;
+		} catch (NoSuchAlgorithmException e) {
+			logger.error("Invalid algorithm!", e);
+			return null;
+		}
+	}
+
+	/**
+	 * Serialized a Serializable object into an encrypted byte array
+	 * @param object Object to serialize
+	 * @param nonce Nonce for encryption
+	 * @return Encrypted serialized object
+	 * @throws IOException
+	 * @throws NoSuchAlgorithmException
+	 * @throws InvalidKeySpecException
+	 * @throws InvalidCipherTextException
+	 */
+	byte[] serialize(Serializable object, byte[] nonce) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidCipherTextException {
+		checkInitCalled();
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(object);
+		oos.close();
+		return cryptoutils.encrypt(keyParameter, nonce, baos.toByteArray(), null);
+	}
+
+	/**
+	 * Deserializes an encrypted object
+	 * @param input Encrypted byte array to deserialize
+	 * @param nonce Nonce for decryption
+	 * @return Deserialized object
+	 * @throws InvalidCipherTextException
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 */
+	Object deserialize(byte[] input, byte[] nonce) throws InvalidCipherTextException, IOException, ClassNotFoundException {
+		checkInitCalled();
+		ByteArrayInputStream bais = new ByteArrayInputStream(cryptoutils.decrypt(keyParameter, nonce, input, null));
+		try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+			return ois.readObject();
+		}
+	}
+}

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -171,13 +171,13 @@ public abstract class Persistence {
 	 * @throws InvalidKeySpecException
 	 * @throws InvalidCipherTextException
 	 */
-	byte[] serialize(Serializable object, byte[] nonce) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidCipherTextException {
+	byte[] serialize(String id, Serializable object, byte[] nonce) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidCipherTextException {
 		checkInitCalled();
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		ObjectOutputStream oos = new ObjectOutputStream(baos);
 		oos.writeObject(object);
 		oos.close();
-		return cryptoutils.encrypt(keyParameter, nonce, baos.toByteArray(), null);
+		return cryptoutils.encrypt(keyParameter, nonce, baos.toByteArray(), id.getBytes());
 	}
 
 	/**
@@ -189,9 +189,9 @@ public abstract class Persistence {
 	 * @throws IOException
 	 * @throws ClassNotFoundException
 	 */
-	Object deserialize(byte[] input, byte[] nonce) throws InvalidCipherTextException, IOException, ClassNotFoundException {
+	Object deserialize(String id, byte[] input, byte[] nonce) throws InvalidCipherTextException, IOException, ClassNotFoundException {
 		checkInitCalled();
-		ByteArrayInputStream bais = new ByteArrayInputStream(cryptoutils.decrypt(keyParameter, nonce, input, null));
+		ByteArrayInputStream bais = new ByteArrayInputStream(cryptoutils.decrypt(keyParameter, nonce, input, id.getBytes()));
 		try (ObjectInputStream ois = new ObjectInputStream(bais)) {
 			return ois.readObject();
 		}

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -61,7 +61,7 @@ public abstract class Persistence {
 	 * @param newPassword New password
 	 * @return True if password has been changed
 	 */
-	final boolean changePassword(char[] oldPassword, char[] newPassword) {
+	final public boolean changePassword(char[] oldPassword, char[] newPassword) {
 		if (oldPassword == null || newPassword == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
@@ -101,7 +101,7 @@ public abstract class Persistence {
 	 * @param object Entity to persist
 	 * @return Result of the operation
 	 */
-	abstract boolean persistEntity(String id, Serializable object);
+	abstract public boolean persistEntity(String id, Serializable object);
 
 	/**
 	 * Updated a previously stored entity
@@ -109,7 +109,7 @@ public abstract class Persistence {
 	 * @param object Entity to replace stored entity with
 	 * @return Result of the operation
 	 */
-	abstract boolean updateEntity(String id, Serializable object) throws IllegalArgumentException;
+	abstract public boolean updateEntity(String id, Serializable object) throws IllegalArgumentException;
 
 	/**
 	 * Removes a persisted entity
@@ -117,7 +117,7 @@ public abstract class Persistence {
 	 * @param cls Class of persisted entity
 	 * @return Result of the operation
 	 */
-	abstract boolean removeEntity(String id, Class cls);
+	abstract public boolean removeEntity(String id, Class cls);
 
 	/**
 	 * Get an entity
@@ -125,21 +125,21 @@ public abstract class Persistence {
 	 * @param cls Class of the entity to receive
 	 * @return Stored entity or null if entity not found
 	 */
-	abstract Object getEntity(String id, Class cls);
+	abstract public Object getEntity(String id, Class cls);
 
 	/**
 	 * Get all entities of the provides Class
 	 * @param cls Class to get all stored entities for
 	 * @return List of stored entities
 	 */
-	abstract List<Object> getEntities(Class cls);
+	abstract public List<Object> getEntities(Class cls);
 
 	/**
 	 * Drops the table for the provided Class
 	 * @param cls Class to drop table for
 	 * @return Result of the operation
 	 */
-	abstract boolean dropTable(Class cls);
+	abstract public boolean dropTable(Class cls);
 
 	/**
 	 * Derives the encryption key from the password and a salt.

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -112,7 +112,7 @@ public abstract class Persistence<T> {
 	 * @param object Entity to replace stored entity with
 	 * @return Result of the operation
 	 */
-	abstract public boolean updateEntity(String id, Serializable object) throws IllegalArgumentException;
+	abstract public boolean updateEntity(String id, Serializable object);
 
 	/**
 	 * Removes a persisted entity

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -107,7 +107,7 @@ public abstract class Persistence<T> {
 	abstract public boolean persistEntity(String id, Serializable object);
 
 	/**
-	 * Updated a previously stored entity
+	 * Updates a previously stored entity
 	 * @param id ID of the stored entity
 	 * @param object Entity to replace stored entity with
 	 * @return Result of the operation
@@ -165,7 +165,7 @@ public abstract class Persistence<T> {
 	}
 
 	/**
-	 * Serialized a Serializable object into an encrypted byte array
+	 * Serializes a Serializable object into an encrypted byte array
 	 * @param object Object to serialize
 	 * @param nonce Nonce for encryption
 	 * @return Encrypted serialized object

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -249,7 +249,7 @@ public class SQLitePersistence extends Persistence {
 	}
 
 	@Override
-	boolean persistEntity(String id, Serializable object) {
+	public boolean persistEntity(String id, Serializable object) {
 		if (id == null || object == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
@@ -288,7 +288,7 @@ public class SQLitePersistence extends Persistence {
 	}
 
 	@Override
-	boolean updateEntity(String id, Serializable object) {
+	public boolean updateEntity(String id, Serializable object) {
 		if (id == null || object == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
@@ -313,7 +313,7 @@ public class SQLitePersistence extends Persistence {
 	}
 
 	@Override
-	boolean removeEntity(String id, Class cls) {
+	public boolean removeEntity(String id, Class cls) {
 		if (id == null || cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
@@ -336,7 +336,7 @@ public class SQLitePersistence extends Persistence {
 	}
 
 	@Override
-	Object getEntity(String id, Class cls) {
+	public Object getEntity(String id, Class cls) {
 		if (id == null || cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
@@ -359,7 +359,7 @@ public class SQLitePersistence extends Persistence {
 	}
 
 	@Override
-	List<Object> getEntities(Class cls) {
+	public List<Object> getEntities(Class cls) {
 		if (cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
@@ -379,7 +379,7 @@ public class SQLitePersistence extends Persistence {
 	}
 
 	@Override
-	boolean dropTable(Class cls) {
+	public boolean dropTable(Class cls) {
 		if (cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -1,0 +1,329 @@
+package de.qabel.core.config;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+import java.io.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stores entities in a local SQLite database
+ */
+public class SQLitePersistence extends Persistence {
+	private final static Logger logger = LogManager.getLogger(SQLitePersistence.class.getName());
+	private final static String STR_MASTER_KEY = "MASTERKEY";
+	private final static String STR_MASTER_KEY_NONCE = "MASTERKEYNONCE";
+	private final static String STR_SALT = "SALT";
+	private final static String STR_DATA = "DATA";
+
+	private Connection c;
+
+	/**
+	 * Stores entities in a local SQLite database
+	 * @param password Password to encrypt data.
+	 */
+	public SQLitePersistence(String password) {
+		super();
+		try {
+			Class.forName("org.sqlite.JDBC");
+			c = DriverManager.getConnection("jdbc:sqlite:qabel-core.sqlite");
+			createTables();
+			init(password);
+		} catch (SQLException e) {
+			logger.fatal("Cannot connect to SQLite DB!", e);
+		} catch (ClassNotFoundException e) {
+			logger.fatal("Cannot load JDBC class!", e);
+		}
+	}
+
+	@Override
+	byte[] getSalt(boolean forceNewSalt) {
+		byte[] salt = null;
+
+		if (forceNewSalt) {
+			deleteConfigValue(STR_SALT);
+		} else {
+			salt = getConfigValue(STR_SALT);
+		}
+
+		if (salt == null) {
+			salt = cryptoutils.getRandomBytes(SALT_SIZE_BYTE);
+			setConfigValue(STR_SALT, salt);
+		}
+		return salt;
+	}
+
+	@Override
+	KeyParameter getMasterKey(KeyParameter encryptionKey) {
+		byte[] masterKey = null;
+		byte[] masterKeyNonce = getConfigValue(STR_MASTER_KEY_NONCE);
+
+		if (masterKeyNonce != null) {
+			try {
+				masterKey = cryptoutils.decrypt(encryptionKey, masterKeyNonce, getConfigValue(STR_MASTER_KEY), null);
+			} catch (InvalidCipherTextException e) {
+				logger.error("Cannot decrypt master key!", e);
+			}
+		}
+
+		if (masterKey == null) {
+			masterKey = cryptoutils.getRandomBytes(AES_KEY_SIZE_BYTE);
+			masterKeyNonce = cryptoutils.getRandomBytes(NONCE_SIZE_BYTE);
+
+			if (!setConfigValue(STR_MASTER_KEY_NONCE, masterKeyNonce)) {
+				logger.error("Cannot insert master key nonce into database!");
+				return null;
+			}
+
+			try {
+				if (!setConfigValue(STR_MASTER_KEY, cryptoutils.encrypt(encryptionKey, masterKeyNonce, masterKey, null))) {
+					logger.error("Cannot insert master key into database!");
+					return null;
+				}
+			} catch (InvalidCipherTextException e) {
+				logger.error("Cannot encrypt master key!", e);
+				return null;
+			}
+		}
+		return new KeyParameter(masterKey);
+	}
+
+	@Override
+	boolean reEncryptMasterKey(KeyParameter oldKey, KeyParameter newKey) {
+		KeyParameter oldMasterKey = getMasterKey(oldKey);
+		boolean success = false;
+		try {
+			c.setAutoCommit(false);
+
+			deleteConfigValue(STR_MASTER_KEY);
+			deleteConfigValue(STR_MASTER_KEY_NONCE);
+
+			byte[] masterKeyNonce = cryptoutils.getRandomBytes(NONCE_SIZE_BYTE);
+			setConfigValue(STR_MASTER_KEY_NONCE, masterKeyNonce);
+			setConfigValue(STR_MASTER_KEY, cryptoutils.encrypt(newKey, masterKeyNonce, oldMasterKey.getKey(), null));
+
+		} catch (SQLException | InvalidCipherTextException e) {
+			logger.error("Cannot re-encrypt master key!", e);
+			try {
+				c.rollback();
+				c.setAutoCommit(true);
+			} catch (SQLException e1) {
+				logger.error("Cannot rollback changes!", e1);
+			}
+		} finally {
+			try {
+				c.commit();
+				c.setAutoCommit(true);
+				success = true;
+			} catch (SQLException e) {
+				logger.error("Cannot apply changes!", e);
+			}
+		}
+		return success;
+	}
+
+	private void createTables(){
+		try {
+			String sql = "CREATE TABLE IF NOT EXISTS CONFIG " +
+					"(ID TEXT PRIMARY KEY NOT NULL," +
+					"DATA TEXT NOT NULL)";
+			Statement statement = c.createStatement();
+			statement.executeUpdate(sql);
+			statement.close();
+		} catch (SQLException e) {
+			logger.error("Cannot create CONFIG table!", e);
+		}
+	}
+
+	private byte[] getConfigValue(String name) {
+		byte[] value = null;
+		try {
+			String sql = "SELECT DATA FROM CONFIG WHERE ID = ?";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setString(1, name);
+			ResultSet rs = statement.executeQuery();
+			if (!rs.isClosed()) {
+				value = rs.getBytes(STR_DATA);
+			}
+			statement.close();
+		} catch (SQLException e) {
+			logger.info("Cannot select " + name + " from CONFIG database!", e);
+		}
+		return value;
+	}
+
+	private boolean setConfigValue(String name, byte[] data) {
+		try {
+			String sql = "INSERT INTO CONFIG " +
+					" VALUES(?, ?)";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setString(1, name);
+			statement.setBytes(2, data);
+			statement.executeUpdate();
+			statement.close();
+		} catch (SQLException e) {
+			logger.info("Cannot insert " + name + " into CONFIG database!", e);
+			return false;
+		}
+		return true;
+	}
+
+	private boolean deleteConfigValue(String name) {
+		try {
+			String sql = "DELETE FROM CONFIG WHERE ID = ?";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setString(1, name);
+			statement.executeUpdate();
+			statement.close();
+		} catch (SQLException e) {
+			logger.info("Cannot delete " + name + " from CONFIG database!", e);
+			return false;
+		}
+		return true;
+	}
+
+	private byte[] getNonce(String id, Serializable object) {
+		byte[] nonce = null;
+		try {
+			String sql = "SELECT NONCE FROM " +
+					"\"" + object.getClass().getCanonicalName() + "\"" +
+					" WHERE ID = ?";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setString(1, id);
+			ResultSet rs = statement.executeQuery(sql);
+			nonce = rs.getBytes("NONCE");
+			statement.close();
+		} catch (SQLException e) {
+			logger.error("Cannot get nonce!", e);
+		}
+		return nonce;
+	}
+
+	@Override
+	boolean persistEntity(String id, Serializable object) {
+		try {
+			String sql = "CREATE TABLE IF NOT EXISTS " +
+					"\"" + object.getClass().getCanonicalName() + "\"" +
+					"(ID TEXT PRIMARY KEY NOT NULL," +
+					"NONCE TEXT NOT NULL," +
+					"BLOB TEXT NOT NULL)";
+			Statement statement = c.createStatement();
+			statement.executeUpdate(sql);
+			statement.close();
+		} catch (SQLException e) {
+			logger.error("Cannot create table!", e);
+		}
+
+		try {
+			byte[] nonce = cryptoutils.getRandomBytes(NONCE_SIZE_BYTE);
+			String sql = "INSERT INTO " +
+					"\"" + object.getClass().getCanonicalName() + "\"" +
+					" VALUES(?, ?, ?)";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setString(1, id);
+			statement.setBytes(2, nonce);
+			statement.setBytes(3, serialize(object, nonce));
+			statement.executeUpdate();
+			statement.close();
+		} catch (SQLException | InvalidKeySpecException | InvalidCipherTextException
+				| NoSuchAlgorithmException | IOException e) {
+			logger.error("Cannot persist entity!", e);
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	boolean updateEntity(String id, Serializable object) {
+		try {
+			String sql = "UPDATE " +
+					"\"" + object.getClass().getCanonicalName() + "\"" +
+					"SET BLOB = ? " +
+					" WHERE ID = ?";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setBytes(1, serialize(object, getNonce(id, object)));
+			statement.setString(2, id);
+			statement.executeUpdate();
+			statement.close();
+		} catch (SQLException | IOException | InvalidKeySpecException
+				| InvalidCipherTextException | NoSuchAlgorithmException e) {
+			logger.error("Cannot update entity!", e);
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	boolean removeEntity(String id, Class cls) {
+		try {
+			String sql = "DELETE FROM " +
+					"\"" + cls.getCanonicalName() + "\"" +
+					" WHERE ID = ?";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setString(1, id);
+			statement.executeUpdate();
+			statement.close();
+		} catch (SQLException e) {
+			logger.error("Cannot remove entity!", e);
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	Object getEntity(String id, Class cls) {
+		Object object = null;
+		try {
+			String sql = "SELECT BLOB, NONCE FROM " +
+					"\"" + cls.getCanonicalName() + "\"" +
+					" WHERE ID = ?";
+			PreparedStatement statement = c.prepareStatement(sql);
+			statement.setString(1, id);
+			ResultSet rs = statement.executeQuery(sql);
+			object = deserialize(rs.getBytes("BLOB"), rs.getBytes("NONCE"));
+		} catch (SQLException | InvalidCipherTextException
+				| IOException | ClassNotFoundException e) {
+			logger.error("Cannot get entity!", e);
+		}
+		return object;
+	}
+
+	@Override
+	List<Object> getEntities(Class cls) {
+		List<Object> objects = new ArrayList<>();
+		try {
+			String sql = "SELECT BLOB, NONCE FROM " +
+					"\"" + cls.getCanonicalName() + "\"";
+			Statement statement = c.createStatement();
+			ResultSet rs = statement.executeQuery(sql);
+			while (rs.next()) {
+				objects.add(deserialize(rs.getBytes("BLOB"), rs.getBytes("NONCE")));
+			}
+		} catch (SQLException | InvalidCipherTextException
+				| ClassNotFoundException | IOException e) {
+			logger.error("Cannot get entities!", e);
+		}
+		return objects;
+	}
+
+	@Override
+	boolean dropTable(Class cls) {
+		try {
+			String sql = "DROP TABLE " +
+					"\"" + cls.getCanonicalName() + "\"";
+			Statement statement = c.createStatement();
+			statement.execute(sql);
+			statement.close();
+		} catch (SQLException e) {
+			logger.error("Cannot drop table!" + e);
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -245,7 +245,7 @@ public class SQLitePersistence extends Persistence {
 					"\"" + object.getClass().getCanonicalName() + "\"" +
 					"(ID TEXT PRIMARY KEY NOT NULL," +
 					"NONCE TEXT NOT NULL," +
-					"BLOB TEXT NOT NULL)";
+					"BLOB BLOB NOT NULL)";
 			Statement statement = c.createStatement();
 			statement.executeUpdate(sql);
 			statement.close();

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -21,7 +21,7 @@ public class SQLitePersistence extends Persistence<String> {
 	private final static String STR_DATA = "DATA";
 	private final static String JDBC_CLASS_NAME = "org.sqlite.JDBC";
 	private final static String JDBC_PREFIX = "jdbc:sqlite:";
-	private final static String DEFAULT_DB_NAME = "qabel-core.sqlite";
+	private final static String DEFAULT_DATABASE = "qabel-core.sqlite";
 
 	private Connection c;
 
@@ -29,7 +29,7 @@ public class SQLitePersistence extends Persistence<String> {
 	 * Stores entities in a local SQLite database
 	 */
 	public SQLitePersistence() {
-		super(DEFAULT_DB_NAME);
+		super(DEFAULT_DATABASE);
 	}
 
 	/**
@@ -41,10 +41,10 @@ public class SQLitePersistence extends Persistence<String> {
 	}
 
 	@Override
-	boolean connect(String dbName) {
+	boolean connect(String database) {
 		try {
 			Class.forName(JDBC_CLASS_NAME);
-			c = DriverManager.getConnection(JDBC_PREFIX + dbName);
+			c = DriverManager.getConnection(JDBC_PREFIX + database);
 			createTables();
 		} catch (SQLException e) {
 			logger.fatal("Cannot connect to SQLite DB!", e);

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -239,7 +239,7 @@ public class SQLitePersistence extends Persistence {
 					" WHERE ID = ?";
 			PreparedStatement statement = c.prepareStatement(sql);
 			statement.setString(1, id);
-			ResultSet rs = statement.executeQuery(sql);
+			ResultSet rs = statement.executeQuery();
 			nonce = rs.getBytes("NONCE");
 			statement.close();
 		} catch (SQLException e) {
@@ -350,7 +350,7 @@ public class SQLitePersistence extends Persistence {
 					" WHERE ID = ?";
 			PreparedStatement statement = c.prepareStatement(sql);
 			statement.setString(1, id);
-			ResultSet rs = statement.executeQuery(sql);
+			ResultSet rs = statement.executeQuery();
 			object = deserialize(id, rs.getBytes("BLOB"), rs.getBytes("NONCE"));
 		} catch (SQLException | IllegalArgumentException e) {
 			logger.error("Cannot get entity!", e);

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * Stores entities in a local SQLite database
  */
-public class SQLitePersistence extends Persistence {
+public class SQLitePersistence extends Persistence<String> {
 	private final static Logger logger = LogManager.getLogger(SQLitePersistence.class.getName());
 	private final static String STR_MASTER_KEY = "MASTERKEY";
 	private final static String STR_MASTER_KEY_NONCE = "MASTERKEYNONCE";

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -228,7 +228,7 @@ public class SQLitePersistence extends Persistence {
 			PreparedStatement statement = c.prepareStatement(sql);
 			statement.setString(1, id);
 			statement.setBytes(2, nonce);
-			statement.setBytes(3, serialize(object, nonce));
+			statement.setBytes(3, serialize(id, object, nonce));
 			statement.executeUpdate();
 			statement.close();
 		} catch (SQLException | InvalidKeySpecException | InvalidCipherTextException
@@ -247,7 +247,7 @@ public class SQLitePersistence extends Persistence {
 					"SET BLOB = ? " +
 					" WHERE ID = ?";
 			PreparedStatement statement = c.prepareStatement(sql);
-			statement.setBytes(1, serialize(object, getNonce(id, object)));
+			statement.setBytes(1, serialize(id, object, getNonce(id, object)));
 			statement.setString(2, id);
 			statement.executeUpdate();
 			statement.close();
@@ -286,7 +286,7 @@ public class SQLitePersistence extends Persistence {
 			PreparedStatement statement = c.prepareStatement(sql);
 			statement.setString(1, id);
 			ResultSet rs = statement.executeQuery(sql);
-			object = deserialize(rs.getBytes("BLOB"), rs.getBytes("NONCE"));
+			object = deserialize(id, rs.getBytes("BLOB"), rs.getBytes("NONCE"));
 		} catch (SQLException | InvalidCipherTextException
 				| IOException | ClassNotFoundException e) {
 			logger.error("Cannot get entity!", e);
@@ -298,12 +298,12 @@ public class SQLitePersistence extends Persistence {
 	List<Object> getEntities(Class cls) {
 		List<Object> objects = new ArrayList<>();
 		try {
-			String sql = "SELECT BLOB, NONCE FROM " +
+			String sql = "SELECT ID, BLOB, NONCE FROM " +
 					"\"" + cls.getCanonicalName() + "\"";
 			Statement statement = c.createStatement();
 			ResultSet rs = statement.executeQuery(sql);
 			while (rs.next()) {
-				objects.add(deserialize(rs.getBytes("BLOB"), rs.getBytes("NONCE")));
+				objects.add(deserialize(new String(rs.getBytes("ID")), rs.getBytes("BLOB"), rs.getBytes("NONCE")));
 			}
 		} catch (SQLException | InvalidCipherTextException
 				| ClassNotFoundException | IOException e) {

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -281,8 +281,8 @@ public class SQLitePersistence extends Persistence {
 			statement.executeUpdate();
 			statement.close();
 		} catch (SQLException | IllegalArgumentException e) {
-			logger.error("Cannot persist entity!", e);
-			throw new IllegalArgumentException("Cannot persist entity!");
+			logger.error("Cannot persist or already persisted entity!", e);
+			throw new IllegalArgumentException("Cannot persist or already persisted entity!");
 		}
 		return true;
 	}

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -28,7 +28,7 @@ public class SQLitePersistence extends Persistence {
 	 * Stores entities in a local SQLite database
 	 * @param password Password to encrypt data.
 	 */
-	public SQLitePersistence(String password) {
+	public SQLitePersistence(char[] password) {
 		super();
 		try {
 			Class.forName("org.sqlite.JDBC");

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -116,7 +116,6 @@ public class SQLitePersistence extends Persistence {
 			logger.error("Cannot re-encrypt master key!", e);
 			try {
 				c.rollback();
-				c.setAutoCommit(true);
 			} catch (SQLException e1) {
 				logger.error("Cannot rollback changes!", e1);
 			}

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -117,6 +117,10 @@ public class SQLitePersistence extends Persistence<String> {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
 		KeyParameter oldMasterKey = getMasterKey(oldKey);
+		if (oldMasterKey == null) {
+			logger.error("Cannot decrypt master key. Wrong password?");
+			return false;
+		}
 		boolean success = false;
 		try {
 			c.setAutoCommit(false);

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -19,25 +19,41 @@ public class SQLitePersistence extends Persistence {
 	private final static String STR_MASTER_KEY_NONCE = "MASTERKEYNONCE";
 	private final static String STR_SALT = "SALT";
 	private final static String STR_DATA = "DATA";
+	private final static String JDBC_CLASS_NAME = "org.sqlite.JDBC";
+	private final static String JDBC_PREFIX = "jdbc:sqlite:";
+	private final static String DEFAULT_DB_NAME = "qabel-core.sqlite";
 
 	private Connection c;
 
 	/**
 	 * Stores entities in a local SQLite database
-	 * @param password Password to encrypt data.
 	 */
-	public SQLitePersistence(char[] password) {
-		super();
+	public SQLitePersistence() {
+		super(DEFAULT_DB_NAME);
+	}
+
+	/**
+	 * Stores entities in a local SQLite database
+	 * @param dbName Database file name.
+	 */
+	public SQLitePersistence(String dbName) {
+		super(dbName);
+	}
+
+	@Override
+	boolean connect(String dbName) {
 		try {
-			Class.forName("org.sqlite.JDBC");
-			c = DriverManager.getConnection("jdbc:sqlite:qabel-core.sqlite");
+			Class.forName(JDBC_CLASS_NAME);
+			c = DriverManager.getConnection(JDBC_PREFIX + dbName);
 			createTables();
-			init(password);
 		} catch (SQLException e) {
 			logger.fatal("Cannot connect to SQLite DB!", e);
+			return false;
 		} catch (ClassNotFoundException e) {
 			logger.fatal("Cannot load JDBC class!", e);
+			return false;
 		}
+		return true;
 	}
 
 	@Override

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -225,8 +225,8 @@ public class SQLitePersistence extends Persistence {
 		return true;
 	}
 
-	private byte[] getNonce(String id, Serializable object) {
-		if (id == null || object == null) {
+	private byte[] getNonce(String id, Class cls) {
+		if (id == null || cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
 		if (id.length() == 0) {
@@ -235,7 +235,7 @@ public class SQLitePersistence extends Persistence {
 		byte[] nonce = null;
 		try {
 			String sql = "SELECT NONCE FROM " +
-					"\"" + object.getClass().getCanonicalName() + "\"" +
+					"\"" + cls.getCanonicalName() + "\"" +
 					" WHERE ID = ?";
 			PreparedStatement statement = c.prepareStatement(sql);
 			statement.setString(1, id);
@@ -301,7 +301,7 @@ public class SQLitePersistence extends Persistence {
 					"SET BLOB = ? " +
 					" WHERE ID = ?";
 			PreparedStatement statement = c.prepareStatement(sql);
-			statement.setBytes(1, serialize(id, object, getNonce(id, object)));
+			statement.setBytes(1, serialize(id, object, getNonce(id, object.getClass())));
 			statement.setString(2, id);
 			statement.executeUpdate();
 			statement.close();

--- a/src/main/java/de/qabel/core/crypto/CryptoUtils.java
+++ b/src/main/java/de/qabel/core/crypto/CryptoUtils.java
@@ -99,7 +99,7 @@ public class CryptoUtils {
 	 *            Number of random bytes
 	 * @return byte[ ] with random bytes
 	 */
-	byte[] getRandomBytes(int numBytes) {
+	public byte[] getRandomBytes(int numBytes) {
 		byte[] ranBytes = new byte[numBytes];
 		secRandom.nextBytes(ranBytes);
 		return ranBytes;
@@ -523,7 +523,7 @@ public class CryptoUtils {
 	 * @return encrypted plaintext
 	 * @throws org.bouncycastle.crypto.InvalidCipherTextException on encryption errors
 	 */
-	byte[] encrypt(KeyParameter key, byte[] nonce, byte[] plaintext, byte[] associatedData) throws InvalidCipherTextException {
+	public byte[] encrypt(KeyParameter key, byte[] nonce, byte[] plaintext, byte[] associatedData) throws InvalidCipherTextException {
 		AEADParameters params = new AEADParameters(key, MAC_BIT, nonce, associatedData);
 		GCMBlockCipher gcm = new GCMBlockCipher(new AESEngine());
 		gcm.init(true, params);
@@ -543,7 +543,7 @@ public class CryptoUtils {
 	 * @return encrypted ciphertext
 	 * @throws org.bouncycastle.crypto.InvalidCipherTextException on decryption errors
 	 */
-	byte[] decrypt(KeyParameter key, byte[] nonce, byte[] ciphertext, byte[] associatedData) throws InvalidCipherTextException {
+	public byte[] decrypt(KeyParameter key, byte[] nonce, byte[] ciphertext, byte[] associatedData) throws InvalidCipherTextException {
 		AEADParameters params = new AEADParameters(key, MAC_BIT, nonce, associatedData);
 		GCMBlockCipher gcm = new GCMBlockCipher(new AESEngine());
 		gcm.init(false, params);

--- a/src/test/java/de/qabel/core/config/ContactsActorTest.java
+++ b/src/test/java/de/qabel/core/config/ContactsActorTest.java
@@ -15,6 +15,7 @@ import de.qabel.core.drop.DropURL;
 import de.qabel.core.exceptions.QblDropInvalidURL;
 
 public class ContactsActorTest {
+	private final static char[] encryptionPassword = "qabel".toCharArray();
 	ArrayList<Contact> receivedContacts = null;
 	ContactTestFactory contactFactory = new ContactTestFactory();
 	ContactsTestFactory contactsFactory = new ContactsTestFactory();
@@ -25,6 +26,7 @@ public class ContactsActorTest {
 
 	@Before
 	public void setUp() {
+		Persistence.setPassword(encryptionPassword);
 		contacts = contactsFactory.create();
 		contactsActor = new ContactsActor(contacts);
 	}

--- a/src/test/java/de/qabel/core/config/ContactsActorTest.java
+++ b/src/test/java/de/qabel/core/config/ContactsActorTest.java
@@ -16,7 +16,7 @@ import de.qabel.core.drop.DropURL;
 import de.qabel.core.exceptions.QblDropInvalidURL;
 
 public class ContactsActorTest {
-	private final static String encryptionPassword = "qabel";
+	private final static char[] encryptionPassword = "qabel".toCharArray();
 	ArrayList<Contact> receivedContacts = null;
 	ContactTestFactory contactFactory = new ContactTestFactory();
 	ContactsTestFactory contactsFactory = new ContactsTestFactory();

--- a/src/test/java/de/qabel/core/config/ContactsActorTest.java
+++ b/src/test/java/de/qabel/core/config/ContactsActorTest.java
@@ -227,7 +227,7 @@ public class ContactsActorTest {
 	}
 
 	@Test
-	public void perstistenceTest() throws InterruptedException {
+	public void persistenceTest() throws InterruptedException {
 
 		ContactsActor ca1 = new ContactsActor(encryptionPassword);
 		TestPersistActor tpa = new TestPersistActor();

--- a/src/test/java/de/qabel/core/config/ContactsActorTest.java
+++ b/src/test/java/de/qabel/core/config/ContactsActorTest.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -16,7 +15,6 @@ import de.qabel.core.drop.DropURL;
 import de.qabel.core.exceptions.QblDropInvalidURL;
 
 public class ContactsActorTest {
-	private final static char[] encryptionPassword = "qabel".toCharArray();
 	ArrayList<Contact> receivedContacts = null;
 	ContactTestFactory contactFactory = new ContactTestFactory();
 	ContactsTestFactory contactsFactory = new ContactsTestFactory();
@@ -27,7 +25,6 @@ public class ContactsActorTest {
 
 	@Before
 	public void setUp() {
-		Persistence.setPassword(encryptionPassword);
 		contacts = contactsFactory.create();
 		contactsActor = new ContactsActor(contacts);
 	}
@@ -225,64 +222,6 @@ public class ContactsActorTest {
 		// Assure that new testDropUrl is contained in the DropUrl list
 		Assert.assertTrue(writtenContact1.getDropUrls().contains(testDropUrl));
 		Assert.assertTrue(writtenContact2.getDropUrls().contains(testDropUrl));
-	}
-
-	@Test
-	public void persistenceTest() throws InterruptedException {
-
-		ContactsActor ca1 = new ContactsActor();
-		TestPersistActor tpa = new TestPersistActor();
-
-		Contact testContactAddMulti1 = contactFactory.create();
-		Contact testContactAddMulti2 = contactFactory.create();
-
-		Thread actorThread = new Thread(tpa);
-		Thread contactActorThread = new Thread(ca1);
-		actorThread.start();
-		contactActorThread.start();
-		tpa.writeContacts(ca1, testContactAddMulti1, testContactAddMulti2);
-		contactActorThread.join();
-		actorThread.join();
-
-		ContactsActor ca2 = new ContactsActor();
-		TestPersistActor tpa2 = new TestPersistActor();
-
-		Thread actorThread2 = new Thread(tpa2);
-		Thread contactActorThread2 = new Thread(ca2);
-		actorThread2.start();
-		contactActorThread2.start();
-		List<Contact> c = new ArrayList<>();
-		tpa2.retrieveContacts(ca2, c);
-		actorThread2.join();
-
-		tpa2.removeContacts(ca2, testContactAddMulti1.getKeyIdentifier());
-		tpa2.removeContacts(ca2, testContactAddMulti2.getKeyIdentifier());
-		actorThread2.join();
-
-		Assert.assertTrue(c.contains(testContactAddMulti1));
-		Assert.assertTrue(c.contains(testContactAddMulti2));
-	}
-
-	class TestPersistActor extends Actor {
-		public void retrieveContacts(ContactsActor ca, final List<Contact> contacts, String...data) {
-			ca.retrieveContacts(this, new Responsible() {
-				@Override
-				public void onResponse(Serializable... data) {
-					for (Contact c : Arrays.asList((Contact[]) data)) {
-						contacts.add(c);
-					}
-					stop();
-				}
-			}, data);
-		}
-		public void writeContacts(ContactsActor ca, Contact...data) {
-			ca.writeContacts(data);
-			stop();
-		}
-		public void removeContacts(ContactsActor ca, String...data) {
-			ca.removeContacts(data);
-			stop();
-		}
 	}
 
 	class TestActor extends Actor {

--- a/src/test/java/de/qabel/core/config/ContactsActorTest.java
+++ b/src/test/java/de/qabel/core/config/ContactsActorTest.java
@@ -27,8 +27,9 @@ public class ContactsActorTest {
 
 	@Before
 	public void setUp() {
+		Persistence.setPassword(encryptionPassword);
 		contacts = contactsFactory.create();
-		contactsActor = new ContactsActor(contacts, encryptionPassword);
+		contactsActor = new ContactsActor(contacts);
 	}
 
 	@Test
@@ -229,7 +230,7 @@ public class ContactsActorTest {
 	@Test
 	public void persistenceTest() throws InterruptedException {
 
-		ContactsActor ca1 = new ContactsActor(encryptionPassword);
+		ContactsActor ca1 = new ContactsActor();
 		TestPersistActor tpa = new TestPersistActor();
 
 		Contact testContactAddMulti1 = contactFactory.create();
@@ -243,7 +244,7 @@ public class ContactsActorTest {
 		contactActorThread.join();
 		actorThread.join();
 
-		ContactsActor ca2 = new ContactsActor(encryptionPassword);
+		ContactsActor ca2 = new ContactsActor();
 		TestPersistActor tpa2 = new TestPersistActor();
 
 		Thread actorThread2 = new Thread(tpa2);

--- a/src/test/java/de/qabel/core/config/PersistenceTest.java
+++ b/src/test/java/de/qabel/core/config/PersistenceTest.java
@@ -1,0 +1,130 @@
+package de.qabel.core.config;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.List;
+
+public class PersistenceTest {
+	private final static char[] encryptionPassword = "qabel".toCharArray();
+	private final static String DB_NAME = "persistenceTest.sqlite";
+	Persistence persistence;
+
+	@Before
+	public void setUp() {
+		Persistence.setPassword(encryptionPassword);
+		persistence = new SQLitePersistence(DB_NAME);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		File persistenceTestDB = new File(DB_NAME);
+		if(persistenceTestDB.exists()) {
+			persistenceTestDB.delete();
+		}
+	}
+
+	@Test
+	public void getEntitiesTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		PersistenceTestObject pto2 = new PersistenceTestObject("pto2");
+
+		Assert.assertTrue(persistence.persistEntity("1", pto));
+		Assert.assertTrue(persistence.persistEntity("2", pto2));
+
+		List<Object> objects = persistence.getEntities(PersistenceTestObject.class);
+		System.out.println(objects.size());
+		Assert.assertTrue(objects.size() == 2);
+		Assert.assertTrue(objects.contains(pto));
+		Assert.assertTrue(objects.contains(pto2));
+	}
+
+	@Test (expected=IllegalArgumentException.class)
+	public void noOverwriteTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		PersistenceTestObject pto2 = new PersistenceTestObject("pto2");
+
+		Assert.assertTrue(persistence.persistEntity("1", pto));
+		persistence.persistEntity("1", pto2);
+	}
+
+	@Test
+	public void updateEntityTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		PersistenceTestObject pto2 = new PersistenceTestObject("pto2");
+
+		Assert.assertTrue(persistence.persistEntity("1", pto));
+		Assert.assertTrue(persistence.updateEntity("1", pto2));
+
+		PersistenceTestObject receivedPto = (PersistenceTestObject) persistence.getEntity("1", PersistenceTestObject.class);
+		Assert.assertNotEquals(pto, receivedPto);
+		Assert.assertEquals(pto2, receivedPto);
+	}
+
+	@Test
+	public void persistenceRoundTripTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		persistence.persistEntity("1", pto);
+
+		// Assure that pto has been persisted
+		PersistenceTestObject receivedPto = (PersistenceTestObject) persistence.getEntity("1", PersistenceTestObject.class);
+		Assert.assertEquals(pto, receivedPto);
+
+		Assert.assertTrue(persistence.removeEntity("1", PersistenceTestObject.class));
+
+		PersistenceTestObject receivedPto2 = (PersistenceTestObject) persistence.getEntity("1", PersistenceTestObject.class);
+		Assert.assertNull(receivedPto2);
+	}
+
+	@Test
+	public void dropTableTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		persistence.persistEntity("1", pto);
+
+		Assert.assertTrue(persistence.dropTable(PersistenceTestObject.class));
+		Assert.assertNull(persistence.getEntity("1", PersistenceTestObject.class));
+	}
+
+	@Test
+	public void changeMasterKeyTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		persistence.persistEntity("1", pto);
+
+		Assert.assertTrue(persistence.changePassword(encryptionPassword, "qabel2".toCharArray()));
+
+		PersistenceTestObject receivedPto = (PersistenceTestObject) persistence.getEntity("1", PersistenceTestObject.class);
+		Assert.assertEquals(pto, receivedPto);
+	}
+
+	static public class PersistenceTestObject implements Serializable {
+		private static final long serialVersionUID = -9721591389456L;
+		public String data;
+
+		public PersistenceTestObject(String data) {
+			this.data = data;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if(this == o) {
+				return true;
+			}
+			if(o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			PersistenceTestObject that = (PersistenceTestObject) o;
+
+			return !(data != null ? !data.equals(that.data) : that.data != null);
+		}
+
+		@Override
+		public int hashCode() {
+			return data != null ? data.hashCode() : 0;
+		}
+	}
+}

--- a/src/test/java/de/qabel/core/config/PersistenceTest.java
+++ b/src/test/java/de/qabel/core/config/PersistenceTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class PersistenceTest {
 	private final static char[] encryptionPassword = "qabel".toCharArray();
 	private final static String DB_NAME = "persistenceTest.sqlite";
-	Persistence persistence;
+	Persistence<String> persistence;
 
 	@Before
 	public void setUp() {

--- a/src/test/java/de/qabel/core/config/PersistenceTest.java
+++ b/src/test/java/de/qabel/core/config/PersistenceTest.java
@@ -29,6 +29,11 @@ public class PersistenceTest {
 	}
 
 	@Test
+	public void getNotPersistedEntityTest() {
+		Assert.assertNull(persistence.getEntity("1", PersistenceTestObject.class));
+	}
+
+	@Test
 	public void getEntitiesTest() {
 		PersistenceTestObject pto = new PersistenceTestObject("pto");
 		PersistenceTestObject pto2 = new PersistenceTestObject("pto2");
@@ -41,6 +46,12 @@ public class PersistenceTest {
 		Assert.assertTrue(objects.size() == 2);
 		Assert.assertTrue(objects.contains(pto));
 		Assert.assertTrue(objects.contains(pto2));
+	}
+
+	@Test
+	public void getEntitiesEmptyTest() {
+		List<Object> objects = persistence.getEntities(PersistenceTestObject.class);
+		Assert.assertEquals(0, objects.size());
 	}
 
 	@Test (expected=IllegalArgumentException.class)
@@ -63,6 +74,21 @@ public class PersistenceTest {
 		PersistenceTestObject receivedPto = (PersistenceTestObject) persistence.getEntity("1", PersistenceTestObject.class);
 		Assert.assertNotEquals(pto, receivedPto);
 		Assert.assertEquals(pto2, receivedPto);
+	}
+
+	@Test
+	public void updateEntityWrongClassTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		PersistenceTestObject2 pto2 = new PersistenceTestObject2("pto2");
+
+		Assert.assertTrue(persistence.persistEntity("1", pto));
+		Assert.assertFalse(persistence.updateEntity("1", pto2));
+	}
+
+	@Test
+	public void updateNotStoredEntityTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		Assert.assertFalse(persistence.updateEntity("1", pto));
 	}
 
 	@Test
@@ -90,6 +116,11 @@ public class PersistenceTest {
 	}
 
 	@Test
+	public void dropNotExistingTableTest() {
+		Assert.assertFalse(persistence.dropTable(PersistenceTestObject.class));
+	}
+
+	@Test
 	public void changeMasterKeyTest() {
 		PersistenceTestObject pto = new PersistenceTestObject("pto");
 		persistence.persistEntity("1", pto);
@@ -100,11 +131,50 @@ public class PersistenceTest {
 		Assert.assertEquals(pto, receivedPto);
 	}
 
+	@Test
+	public void changeMasterKeyFailTest() {
+		PersistenceTestObject pto = new PersistenceTestObject("pto");
+		persistence.persistEntity("1", pto);
+
+		Assert.assertFalse(persistence.changePassword("wrongPassword".toCharArray(), "qabel2".toCharArray()));
+
+		PersistenceTestObject receivedPto = (PersistenceTestObject) persistence.getEntity("1", PersistenceTestObject.class);
+		Assert.assertEquals(pto, receivedPto);
+	}
+
 	static public class PersistenceTestObject implements Serializable {
 		private static final long serialVersionUID = -9721591389456L;
 		public String data;
 
 		public PersistenceTestObject(String data) {
+			this.data = data;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if(this == o) {
+				return true;
+			}
+			if(o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			PersistenceTestObject that = (PersistenceTestObject) o;
+
+			return !(data != null ? !data.equals(that.data) : that.data != null);
+		}
+
+		@Override
+		public int hashCode() {
+			return data != null ? data.hashCode() : 0;
+		}
+	}
+
+	static public class PersistenceTestObject2 implements Serializable {
+		private static final long serialVersionUID = -832569264920L;
+		public String data;
+
+		public PersistenceTestObject2(String data) {
 			this.data = data;
 		}
 

--- a/src/test/java/de/qabel/core/config/PersistenceTest.java
+++ b/src/test/java/de/qabel/core/config/PersistenceTest.java
@@ -42,8 +42,7 @@ public class PersistenceTest {
 		Assert.assertTrue(persistence.persistEntity("2", pto2));
 
 		List<Object> objects = persistence.getEntities(PersistenceTestObject.class);
-		System.out.println(objects.size());
-		Assert.assertTrue(objects.size() == 2);
+		Assert.assertEquals(2, objects.size());
 		Assert.assertTrue(objects.contains(pto));
 		Assert.assertTrue(objects.contains(pto2));
 	}


### PR DESCRIPTION
This PR is based on #305.

This adds a Persistence class to persist Serializable objects. It probably isn't completely finished, but worth a look. SQLitePersistence uses SQLite as a simple blob storage. 

Entity has a new UUID field which can be used to get or remove a specific persisted object. I introduced this artificial ID, because it is stored unencrypted in the database (to allow lookups). Using actual values like the key id would leak this information.

The serialized data is encrypted with AES256 GCM and a random nonce per object. A master key is used to encrypt all objects. This master key itself is also AES256 GCM encrypted with nonce and a key derived from via PBKDF2 from a password and a random salt. This allows easy password changed by just re-encrypting the master key instead of re-encrypting all stored values.

The UUID is provided to the GCM encryption as authenticated data. This detects if somebody switches the encrypted object with another encrypted object.

The ContactActor has been modified to store, delete or get Contacts from the Persistence class.

A simple test has been added, but more tests are required and will follow (password change, deletion, etc.)

How the persistence layer should receive the password has to be determined. Currently, the ContactActor will provide it to the persistence class. This will not be the final concept.

Closes #18 

TODO:
- [x] Add further tests
