### PR TITLE
Refactored DropActor

### DIFF
--- a/src/main/java/de/qabel/core/EventNameConstants.java
+++ b/src/main/java/de/qabel/core/EventNameConstants.java
@@ -1,0 +1,7 @@
+package de.qabel.core;
+
+
+public class EventNameConstants {
+	public static final String EVENT_CONTACT_ADDED = "contactAdded";
+	public static final String EVENT_CONTACT_REMOVED = "contactRemoved";
+}

--- a/src/main/java/de/qabel/core/EventNameConstants.java
+++ b/src/main/java/de/qabel/core/EventNameConstants.java
@@ -4,4 +4,14 @@ package de.qabel.core;
 public class EventNameConstants {
 	public static final String EVENT_CONTACT_ADDED = "contactAdded";
 	public static final String EVENT_CONTACT_REMOVED = "contactRemoved";
+	public static final String EVENT_IDENTITY_ADDED = "identityAdded";
+	public static final String EVENT_IDENTITY_REMOVED = "identityRemoved";
+	public static final String EVENT_DROPSERVER_ADDED ="dropserverAdded";
+	public static final String EVENT_DROPSERVER_REMOVED = "dropserverRemoved";
+	public static final String EVENT_ACCOUNT_ADDED = "accountAdded";
+	public static final String EVENT_STORAGESERVER_ADDED = "storageServerAdded";
+	public static final String EVENT_STORAGEVOLUME_ADDED = "storageVolumeAdded";
+	public static final String EVENT_ACCOUNT_REMOVED = "accountRemoved";
+	public static final String EVENT_STORAGESERVER_REMOVED = "storageServerRemoved";
+	public static final String EVENT_STORAGEVOLUME_REMOVED = "storageVolumeRemoved";
 }

--- a/src/main/java/de/qabel/core/config/AbstractModuleSettings.java
+++ b/src/main/java/de/qabel/core/config/AbstractModuleSettings.java
@@ -2,7 +2,7 @@ package de.qabel.core.config;
 
 import java.io.Serializable;
 
-public abstract class AbstractModuleSettings implements Serializable {
+public abstract class AbstractModuleSettings extends Persistable implements Serializable {
 	private static final long serialVersionUID = -2650189278846561182L;
 	private String type;
 

--- a/src/main/java/de/qabel/core/config/AbstractModuleSettings.java
+++ b/src/main/java/de/qabel/core/config/AbstractModuleSettings.java
@@ -2,7 +2,7 @@ package de.qabel.core.config;
 
 import java.io.Serializable;
 
-public abstract class AbstractModuleSettings extends Persistable implements Serializable {
+public abstract class AbstractModuleSettings extends Persistable {
 	private static final long serialVersionUID = -2650189278846561182L;
 	private String type;
 

--- a/src/main/java/de/qabel/core/config/Accounts.java
+++ b/src/main/java/de/qabel/core/config/Accounts.java
@@ -1,26 +1,32 @@
 package de.qabel.core.config;
 
-import java.util.Collections;
-import java.util.Set;
-import java.util.HashSet;
+import java.util.*;
 
 /**
  * https://github.com/Qabel/qabel-doc/wiki/Qabel-Client-Configuration#accounts
  */
 public class Accounts {
 
-	private final Set<Account> accounts = new HashSet<Account>();
+	private final Map<String, Account> accounts = new HashMap<>();
 
 	/**
 	 * Returns unmodifiable set of contained accounts
 	 * @return Set<Account>
 	 */
 	public Set<Account> getAccounts() {
-		return Collections.unmodifiableSet(this.accounts);
+		return Collections.unmodifiableSet(new HashSet<>(this.accounts.values()));
 	}
-	
+
+	/**
+	 * Adds or updated an account
+	 * @param account Account to add or update
+	 * @return True if newly added, false if updated
+	 */
 	public boolean add(Account account) {
-		return this.accounts.add(account);
+		if (this.accounts.put(account.getPersistenceID(), account) == null) {
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -29,12 +35,10 @@ public class Accounts {
 	 * @return true if account was contained in list, false if not
 	 */
 	public boolean remove(Account account) {
-		return this.accounts.remove(account);
-	}
-
-	public boolean update(Account account) {
-		this.remove(account);
-		return this.add(account);
+		if (this.accounts.remove(account.getPersistenceID()) == null) {
+			return false;
+		}
+		return true;
 	}
 
 	@Override
@@ -61,7 +65,4 @@ public class Accounts {
 			return false;
 		return true;
 	}
-	
-	
-
 }

--- a/src/main/java/de/qabel/core/config/Accounts.java
+++ b/src/main/java/de/qabel/core/config/Accounts.java
@@ -18,11 +18,11 @@ public class Accounts {
 	}
 
 	/**
-	 * Adds or updated an account
-	 * @param account Account to add or update
+	 * Put an account
+	 * @param account Account to put
 	 * @return True if newly added, false if updated
 	 */
-	public boolean add(Account account) {
+	public boolean put(Account account) {
 		if (this.accounts.put(account.getPersistenceID(), account) == null) {
 			return true;
 		}

--- a/src/main/java/de/qabel/core/config/AccountsTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/AccountsTypeAdapter.java
@@ -39,7 +39,7 @@ public class AccountsTypeAdapter extends TypeAdapter<Accounts> {
 		in.beginArray();
 		while(in.hasNext()) {
 			account = adapter.read(in);
-			accounts.add(account);
+			accounts.put(account);
 		}
 		in.endArray();
 		

--- a/src/main/java/de/qabel/core/config/ConfigActor.java
+++ b/src/main/java/de/qabel/core/config/ConfigActor.java
@@ -1,8 +1,11 @@
 package de.qabel.core.config;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.Set;
 
+import de.qabel.ackack.event.EventEmitter;
+import de.qabel.core.EventNameConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -17,6 +20,9 @@ import de.qabel.ackack.Responsible;
 public class ConfigActor extends Actor {
 	private static ConfigActor defaultConfigActor = null;
 	private Settings settings;
+	private EventEmitter eventEmitter;
+	private Persistence persistence;
+
 	private static final String RETRIEVE_ACCOUNTS = "retrieveAccounts";
 	private static final String RETRIEVE_DROPSERVERS = "retrieveDropServers";
 	private static final String RETRIEVE_IDENTITIES = "retrieveIdentities";
@@ -45,15 +51,55 @@ public class ConfigActor extends Actor {
 
 	private final static Logger logger = LogManager.getLogger(ConfigActor.class.getName());
 
-	static ConfigActor getDefault() {
+	public static ConfigActor getDefault() {
 		if(defaultConfigActor == null) {
-			defaultConfigActor = new ConfigActor(new Settings());
+			defaultConfigActor = new ConfigActor(new Settings(), EventEmitter.getDefault());
 		}
 		return defaultConfigActor;
 	}
 
-	public ConfigActor(Settings settings) {
-		this.settings= settings;
+	public ConfigActor(Settings settings, EventEmitter eventEmitter) {
+		this.persistence = new SQLitePersistence();
+		this.settings = settings;
+		//TODO: DEFAULT SETTINGS?!?
+		settings.setLocalSettings(new LocalSettings(1000L, new Date()));
+		settings.setSyncedSettings(new SyncedSettings());
+		this.eventEmitter = eventEmitter;
+		loadFromPersistence();
+	}
+
+	private void loadFromPersistence() {
+		for (Object object: persistence.getEntities(Account.class)) {
+			settings.getSyncedSettings().getAccounts().add((Account) object);
+		}
+
+		for (Object object: persistence.getEntities(DropServer.class)) {
+			settings.getSyncedSettings().getDropServers().add((DropServer) object);
+		}
+
+		for (Object object: persistence.getEntities(Identity.class)) {
+			settings.getSyncedSettings().getIdentities().add((Identity) object);
+		}
+
+		for (Object object: persistence.getEntities(LocaleModuleSettings.class)) {
+			settings.getLocalSettings().getLocaleModuleSettings().add((LocaleModuleSettings) object);
+		}
+
+		for (Object object: persistence.getEntities(LocalSettings.class)) {
+			settings.setLocalSettings((LocalSettings) object);
+		}
+
+		for (Object object: persistence.getEntities(StorageServer.class)) {
+			settings.getSyncedSettings().getStorageServers().add((StorageServer) object);
+		}
+
+		for (Object object: persistence.getEntities(StorageVolume.class)) {
+			settings.getSyncedSettings().getStorageVolumes().add((StorageVolume) object);
+		}
+
+		for (Object object: persistence.getEntities(SyncedModuleSettings.class)) {
+			settings.getSyncedSettings().getSyncedModuleSettings().add((SyncedModuleSettings) object);
+		}
 	}
 
 	/**
@@ -335,158 +381,231 @@ public class ConfigActor extends Actor {
 
 	@Override
 	protected void react(MessageInfo info, Object... data) {
-		Accounts accounts;
-		DropServers dropServers;
-		Identities identities;
-		Set<LocaleModuleSettings> localModuleSettingsList;
-		StorageServers storageServers;
-		StorageVolumes storageVolumes;
-		Set<SyncedModuleSettings> syncedModuleSettingsList;
+		switch (info.getType()) {
+			case RETRIEVE_ACCOUNTS:
+				synchronized (settings.getSyncedSettings().getAccounts()) {
+					info.response((Serializable[]) this.settings
+							.getSyncedSettings().getAccounts().getAccounts()
+							.toArray(new Account[0]));
+				}
+				break;
+			case RETRIEVE_DROPSERVERS:
+				synchronized (settings.getSyncedSettings().getDropServers()) {
+					info.response((Serializable[]) this.settings
+							.getSyncedSettings().getDropServers().getDropServers()
+							.toArray(new DropServer[0]));
+				}
+				break;
+			case RETRIEVE_IDENTITIES:
+				synchronized (settings.getSyncedSettings().getIdentities()) {
+					info.response((Serializable[]) this.settings
+							.getSyncedSettings().getIdentities().getIdentities()
+							.toArray(new Identity[0]));
+				}
+				break;
+			case RETRIEVE_LOCALMODULESETTINGS:
+				synchronized (settings.getLocalSettings().getLocaleModuleSettings()) {
+					info.response((Serializable[]) this.settings
+							.getLocalSettings().getLocaleModuleSettings()
+							.toArray(new LocaleModuleSettings[0]));
+				}
+				break;
+			case RETRIEVE_LOCALSETTINGS:
+				synchronized (settings.getLocalSettings()) {
+					info.response((Serializable) this.settings.getLocalSettings());
+				}
+				break;
+			case RETRIEVE_STORAGESERVERS:
+				synchronized (settings.getSyncedSettings().getStorageServers()) {
+					info.response((Serializable[]) this.settings
+							.getSyncedSettings().getStorageServers()
+							.getStorageServers().toArray(new StorageServer[0]));
+				}
+				break;
+			case RETRIEVE_STORAGEVOLUMES:
+				synchronized (settings.getSyncedSettings().getStorageVolumes()) {
+					info.response((Serializable[]) this.settings
+							.getSyncedSettings().getStorageVolumes()
+							.getStorageVolumes().toArray(new StorageVolume[0]));
+				}
+				break;
+			case RETRIEVE_SYNCEDMODULESETTINGS:
+				synchronized (settings.getSyncedSettings().getSyncedModuleSettings()) {
+					info.response((Serializable[]) this.settings
+							.getSyncedSettings().getSyncedModuleSettings()
+							.toArray(new SyncedModuleSettings[0]));
+				}
+				break;
+			case WRITE_ACCOUNTS:
+				synchronized (settings.getSyncedSettings().getAccounts()) {
+					Accounts accounts = this.settings.getSyncedSettings().getAccounts();
+					for (Object object : data) {
+						Account account = (Account) object;
+						accounts.add(account);
+						persistence.updateOrPersistEntity(account);
+						eventEmitter.emit(EventNameConstants.EVENT_ACCOUNT_ADDED, account);
+					}
+				}
+				break;
+			case WRITE_DROPSERVERS:
+				synchronized (settings.getSyncedSettings().getDropServers()) {
+					DropServers dropServers = this.settings.getSyncedSettings().getDropServers();
+					for (Object object : data) {
+						DropServer dropServer = (DropServer) object;
+						dropServers.add(dropServer);
+						persistence.updateOrPersistEntity(dropServer);
+						eventEmitter.emit(EventNameConstants.EVENT_DROPSERVER_ADDED, dropServer);
+					}
+				}
+				break;
+			case WRITE_IDENTITIES:
+				synchronized (settings.getSyncedSettings().getIdentities()) {
+					Identities identities = this.settings.getSyncedSettings().getIdentities();
+					for (Object object : data) {
+						Identity identity = (Identity) object;
+						identities.add(identity);
+						persistence.updateOrPersistEntity(identity);
+						eventEmitter.emit(EventNameConstants.EVENT_IDENTITY_ADDED, identity);
+					}
+				}
+				break;
+			case WRITE_LOCALMODULESETTINGS:
+				synchronized (settings.getLocalSettings().getLocaleModuleSettings()) {
+					Set<LocaleModuleSettings> localModuleSettingsList = this.settings.getLocalSettings()
+							.getLocaleModuleSettings();
+					for (Object object : data) {
+						LocaleModuleSettings localModuleSettings = (LocaleModuleSettings) object;
+						localModuleSettingsList.remove(localModuleSettings);
+						localModuleSettingsList.add(localModuleSettings);
+						persistence.updateOrPersistEntity(localModuleSettings);
+						//TODO: EMIT THIS EVENT?
+					}
+				}
+				break;
+			case WRITE_LOCALSETTINGS:
+				synchronized (settings.getLocalSettings()) {
+					this.settings.setLocalSettings((LocalSettings) data[0]);
+					persistence.updateOrPersistEntity((LocalSettings) data[0]);
+				}
+				break;
+			case WRITE_STORAGESERVERS:
+				synchronized (settings.getSyncedSettings().getStorageServers()) {
+					StorageServers storageServers = this.settings.getSyncedSettings().getStorageServers();
+					for (Object object : data) {
+						StorageServer storageServer = (StorageServer) object;
+						storageServers.add(storageServer);
+						persistence.updateOrPersistEntity(storageServer);
+						eventEmitter.emit(EventNameConstants.EVENT_STORAGESERVER_ADDED, storageServer);
+					}
+				}
+				break;
+			case WRITE_STORAGEVOLUMES:
+				synchronized (settings.getSyncedSettings().getStorageVolumes()) {
+					StorageVolumes storageVolumes = this.settings.getSyncedSettings().getStorageVolumes();
+					for (Object object : data) {
+						StorageVolume storageVolume = (StorageVolume) object;
+						storageVolumes.add(storageVolume);
+						persistence.updateOrPersistEntity(storageVolume);
+						eventEmitter.emit(EventNameConstants.EVENT_STORAGEVOLUME_ADDED, storageVolume);
+					}
+				}
+				break;
+			case WRITE_SYNCEDMODULESETTINGS:
+				synchronized (settings.getSyncedSettings().getSyncedModuleSettings()) {
+					Set<SyncedModuleSettings> syncedModuleSettingsList = this.settings.getSyncedSettings()
+							.getSyncedModuleSettings();
+					for (Object object : data) {
+						SyncedModuleSettings syncedModuleSettings = (SyncedModuleSettings) object;
+						syncedModuleSettingsList.remove(syncedModuleSettings);
+						syncedModuleSettingsList.add(syncedModuleSettings);
+						persistence.updateOrPersistEntity(syncedModuleSettings);
+						//TODO: EMIT THIS EVENT?
+					}
+				}
+				break;
+			case REMOVE_ACCOUNTS:
+				synchronized (settings.getSyncedSettings().getAccounts()) {
+					Accounts accounts = this.settings.getSyncedSettings().getAccounts();
+					for (Object object : data) {
+						Account account = (Account) object;
+						accounts.remove(account);
+						persistence.removeEntity(account.getPersistenceID(), account.getClass());
+						eventEmitter.emit(EventNameConstants.EVENT_ACCOUNT_REMOVED, account);
+					}
+				}
+				break;
+			case REMOVE_DROPSERVERS:
+				synchronized (settings.getSyncedSettings().getDropServers()) {
+					DropServers dropServers = this.settings.getSyncedSettings().getDropServers();
+					for (Object object : data) {
+						DropServer dropServer = (DropServer) object;
+						dropServers.remove(dropServer);
+						persistence.removeEntity(dropServer.getPersistenceID(), dropServer.getClass());
+						eventEmitter.emit(EventNameConstants.EVENT_DROPSERVER_REMOVED, dropServer);
+					}
+				}
+				break;
+			case REMOVE_IDENTITIES:
+				synchronized (settings.getSyncedSettings().getIdentities()) {
+					Identities identities = this.settings.getSyncedSettings().getIdentities();
+					for (Object object : data) {
+						Identity identity = (Identity) object;
+						identities.remove(identity);
+						persistence.removeEntity(identity.getPersistenceID(), identity.getClass());
+						eventEmitter.emit(EventNameConstants.EVENT_IDENTITY_REMOVED, identity.getKeyIdentifier());
+					}
+				}
+				break;
+			case REMOVE_LOCALMODULESETTINGS:
+				synchronized (settings.getLocalSettings().getLocaleModuleSettings()) {
+					Set<LocaleModuleSettings> localModuleSettingsList = this.settings.getLocalSettings()
+							.getLocaleModuleSettings();
+					for (Object object : data) {
+						LocaleModuleSettings localModuleSettings = (LocaleModuleSettings) object;
+						localModuleSettingsList.remove(localModuleSettings);
+						persistence.removeEntity(localModuleSettings.getPersistenceID(), localModuleSettings.getClass());
+						//TODO: EMIT THIS EVENT?
+					}
+				}
+				break;
+			case REMOVE_STORAGESERVERS:
+				synchronized (settings.getSyncedSettings().getStorageServers()) {
+					StorageServers storageServers = this.settings.getSyncedSettings().getStorageServers();
+					for (Object object : data) {
+						StorageServer storageServer = (StorageServer) object;
+						storageServers.remove(storageServer);
+						persistence.removeEntity(storageServer.getPersistenceID(), storageServer.getClass());
+						eventEmitter.emit(EventNameConstants.EVENT_STORAGESERVER_REMOVED, storageServer);
+					}
+				}
+				break;
+			case REMOVE_STORAGEVOLUMES:
+				synchronized (settings.getSyncedSettings().getStorageVolumes()) {
+					StorageVolumes storageVolumes = this.settings.getSyncedSettings().getStorageVolumes();
+					for (Object object : data) {
+						StorageVolume storageVolume = (StorageVolume) object;
+						storageVolumes.remove(storageVolume);
+						persistence.removeEntity(storageVolume.getPersistenceID(), storageVolume.getClass());
+						eventEmitter.emit(EventNameConstants.EVENT_STORAGEVOLUME_REMOVED, storageVolume);
+					}
+				}
+				break;
+			case REMOVE_SYNCEDMODULESETTINGS:
+				synchronized (settings.getSyncedSettings().getSyncedModuleSettings()) {
+					Set<SyncedModuleSettings> syncedModuleSettingsList = this.settings.getSyncedSettings()
+							.getSyncedModuleSettings();
+					for (Object object : data) {
+						SyncedModuleSettings syncedModuleSettings = (SyncedModuleSettings) object;
+						syncedModuleSettingsList.remove(syncedModuleSettings);
+						persistence.removeEntity(syncedModuleSettings.getPersistenceID(), syncedModuleSettings.getClass());
+						//TODO: EMIT THIS EVENT?
+					}
+				}
+				break;
+			default:
+				logger.debug("Unexpected type of MessageInfo: \"" + info.getType() + "\"");
+				break;
 
-		switch(info.getType()) {
-		case RETRIEVE_ACCOUNTS:
-			info.response((Serializable[]) this.settings
-					.getSyncedSettings().getAccounts().getAccounts()
-					.toArray(new Account[0]));
-			break;
-		case RETRIEVE_DROPSERVERS:
-			info.response((Serializable[]) this.settings
-					.getSyncedSettings().getDropServers().getDropServers()
-					.toArray(new DropServer[0]));
-			break;
-		case RETRIEVE_IDENTITIES:
-			info.response((Serializable[]) this.settings
-					.getSyncedSettings().getIdentities().getIdentities()
-					.toArray(new Identity[0]));
-			break;
-		case RETRIEVE_LOCALMODULESETTINGS:
-			info.response((Serializable[]) this.settings
-					.getLocalSettings().getLocaleModuleSettings()
-					.toArray(new LocaleModuleSettings[0]));
-			break;
-		case RETRIEVE_LOCALSETTINGS:
-			info.response((Serializable) this.settings.getLocalSettings());
-			break;
-		case RETRIEVE_STORAGESERVERS:
-			info.response((Serializable[]) this.settings
-					.getSyncedSettings().getStorageServers()
-					.getStorageServers().toArray(new StorageServer[0]));
-			break;
-		case RETRIEVE_STORAGEVOLUMES:
-			info.response((Serializable[]) this.settings
-					.getSyncedSettings().getStorageVolumes()
-					.getStorageVolumes().toArray(new StorageVolume[0]));
-			break;
-		case RETRIEVE_SYNCEDMODULESETTINGS:
-			info.response((Serializable[]) this.settings
-					.getSyncedSettings().getSyncedModuleSettings()
-					.toArray(new SyncedModuleSettings[0]));
-			break;
-		case WRITE_ACCOUNTS:
-			accounts = this.settings.getSyncedSettings()
-				.getAccounts();
-			for(int i = 0; i< data.length; i++) {
-				accounts.update((Account) data[i]);
-			}
-			break;
-		case WRITE_DROPSERVERS:
-			dropServers = this.settings.getSyncedSettings()
-				.getDropServers();
-			for(int i = 0; i< data.length; i++) {
-				dropServers.update((DropServer) data[i]);
-			}
-			break;
-		case WRITE_IDENTITIES:
-			identities = this.settings.getSyncedSettings()
-				.getIdentities();
-			for(int i = 0; i< data.length; i++) {
-				identities.replace((Identity) data[i]);
-			}
-			break;
-		case WRITE_LOCALMODULESETTINGS:
-			localModuleSettingsList = this.settings.getLocalSettings()
-				.getLocaleModuleSettings();
-			for(int i = 0; i< data.length; i++) {
-				localModuleSettingsList.remove((LocaleModuleSettings) data[i]);
-				localModuleSettingsList.add((LocaleModuleSettings) data[i]);
-			}
-			break;
-		case WRITE_LOCALSETTINGS:
-			this.settings.setLocalSettings((LocalSettings) data[0]);
-			break;
-		case WRITE_STORAGESERVERS:
-			storageServers = this.settings.getSyncedSettings()
-				.getStorageServers();
-			for(int i = 0; i< data.length; i++) {
-				storageServers.update((StorageServer) data[i]);
-			}
-			break;
-		case WRITE_STORAGEVOLUMES:
-			storageVolumes = this.settings.getSyncedSettings()
-				.getStorageVolumes();
-			for(int i = 0; i< data.length; i++) {
-				storageVolumes.update((StorageVolume) data[i]);
-			}
-			break;
-		case WRITE_SYNCEDMODULESETTINGS:
-			syncedModuleSettingsList = this.settings.getSyncedSettings()
-				.getSyncedModuleSettings();
-			for(int i = 0; i< data.length; i++) {
-				syncedModuleSettingsList.remove((SyncedModuleSettings) data[i]);
-				syncedModuleSettingsList.add((SyncedModuleSettings) data[i]);
-			}
-			break;
-		case REMOVE_ACCOUNTS:
-			accounts = this.settings.getSyncedSettings().getAccounts();
-			for(int i = 0; i< data.length; i++) {
-				accounts.remove((Account) data[i]);
-			}
-			break;
-		case REMOVE_DROPSERVERS:
-			dropServers = this.settings.getSyncedSettings().getDropServers();
-			for(int i = 0; i< data.length; i++) {
-				dropServers.remove((DropServer) data[i]);
-			}
-			break;
-		case REMOVE_IDENTITIES:
-			identities = this.settings.getSyncedSettings().getIdentities();
-			for(int i = 0; i< data.length; i++) {
-				identities.remove((Identity) data[i]);
-			}
-			break;
-		case REMOVE_LOCALMODULESETTINGS:
-			localModuleSettingsList = this.settings.getLocalSettings()
-				.getLocaleModuleSettings();
-			for(int i = 0; i< data.length; i++) {
-				localModuleSettingsList.remove((LocaleModuleSettings) data[i]);
-			}
-			break;
-		case REMOVE_STORAGESERVERS:
-			storageServers = this.settings.getSyncedSettings()
-				.getStorageServers();
-			for(int i = 0; i< data.length; i++) {
-				storageServers.remove((StorageServer) data[i]);
-			}
-			break;
-		case REMOVE_STORAGEVOLUMES:
-			storageVolumes = this.settings.getSyncedSettings()
-				.getStorageVolumes();
-			for(int i = 0; i< data.length; i++) {
-				storageVolumes.remove((StorageVolume) data[i]);
-			}
-			break;
-		case REMOVE_SYNCEDMODULESETTINGS:
-			syncedModuleSettingsList = this.settings.getSyncedSettings()
-				.getSyncedModuleSettings();
-			for(int i = 0; i< data.length; i++) {
-				syncedModuleSettingsList.remove((SyncedModuleSettings) data[i]);
-			}
-			break;
-		default:
-			logger.debug("Unexpected type of MessageInfo: \"" + info.getType()
-					+ "\"");
-			break;
 		}
-		stop();
 	}
 }

--- a/src/main/java/de/qabel/core/config/ConfigActor.java
+++ b/src/main/java/de/qabel/core/config/ConfigActor.java
@@ -70,15 +70,15 @@ public class ConfigActor extends Actor {
 
 	private void loadFromPersistence() {
 		for (Object object: persistence.getEntities(Account.class)) {
-			settings.getSyncedSettings().getAccounts().add((Account) object);
+			settings.getSyncedSettings().getAccounts().put((Account) object);
 		}
 
 		for (Object object: persistence.getEntities(DropServer.class)) {
-			settings.getSyncedSettings().getDropServers().add((DropServer) object);
+			settings.getSyncedSettings().getDropServers().put((DropServer) object);
 		}
 
 		for (Object object: persistence.getEntities(Identity.class)) {
-			settings.getSyncedSettings().getIdentities().add((Identity) object);
+			settings.getSyncedSettings().getIdentities().put((Identity) object);
 		}
 
 		for (Object object: persistence.getEntities(LocaleModuleSettings.class)) {
@@ -90,11 +90,11 @@ public class ConfigActor extends Actor {
 		}
 
 		for (Object object: persistence.getEntities(StorageServer.class)) {
-			settings.getSyncedSettings().getStorageServers().add((StorageServer) object);
+			settings.getSyncedSettings().getStorageServers().put((StorageServer) object);
 		}
 
 		for (Object object: persistence.getEntities(StorageVolume.class)) {
-			settings.getSyncedSettings().getStorageVolumes().add((StorageVolume) object);
+			settings.getSyncedSettings().getStorageVolumes().put((StorageVolume) object);
 		}
 
 		for (Object object: persistence.getEntities(SyncedModuleSettings.class)) {
@@ -441,7 +441,7 @@ public class ConfigActor extends Actor {
 					Accounts accounts = this.settings.getSyncedSettings().getAccounts();
 					for (Object object : data) {
 						Account account = (Account) object;
-						accounts.add(account);
+						accounts.put(account);
 						persistence.updateOrPersistEntity(account);
 						eventEmitter.emit(EventNameConstants.EVENT_ACCOUNT_ADDED, account);
 					}
@@ -452,7 +452,7 @@ public class ConfigActor extends Actor {
 					DropServers dropServers = this.settings.getSyncedSettings().getDropServers();
 					for (Object object : data) {
 						DropServer dropServer = (DropServer) object;
-						dropServers.add(dropServer);
+						dropServers.put(dropServer);
 						persistence.updateOrPersistEntity(dropServer);
 						eventEmitter.emit(EventNameConstants.EVENT_DROPSERVER_ADDED, dropServer);
 					}
@@ -463,7 +463,7 @@ public class ConfigActor extends Actor {
 					Identities identities = this.settings.getSyncedSettings().getIdentities();
 					for (Object object : data) {
 						Identity identity = (Identity) object;
-						identities.add(identity);
+						identities.put(identity);
 						persistence.updateOrPersistEntity(identity);
 						eventEmitter.emit(EventNameConstants.EVENT_IDENTITY_ADDED, identity);
 					}
@@ -493,7 +493,7 @@ public class ConfigActor extends Actor {
 					StorageServers storageServers = this.settings.getSyncedSettings().getStorageServers();
 					for (Object object : data) {
 						StorageServer storageServer = (StorageServer) object;
-						storageServers.add(storageServer);
+						storageServers.put(storageServer);
 						persistence.updateOrPersistEntity(storageServer);
 						eventEmitter.emit(EventNameConstants.EVENT_STORAGESERVER_ADDED, storageServer);
 					}
@@ -504,7 +504,7 @@ public class ConfigActor extends Actor {
 					StorageVolumes storageVolumes = this.settings.getSyncedSettings().getStorageVolumes();
 					for (Object object : data) {
 						StorageVolume storageVolume = (StorageVolume) object;
-						storageVolumes.add(storageVolume);
+						storageVolumes.put(storageVolume);
 						persistence.updateOrPersistEntity(storageVolume);
 						eventEmitter.emit(EventNameConstants.EVENT_STORAGEVOLUME_ADDED, storageVolume);
 					}

--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -2,7 +2,6 @@ package de.qabel.core.config;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.List;
 
 import de.qabel.ackack.Actor;
 import de.qabel.ackack.MessageInfo;
@@ -45,11 +44,8 @@ public class ContactsActor extends Actor {
 		this.contacts = contacts;
 		this.eventEmitter = EventEmitter.getDefault();
 
-		List persistenceEntities = persistence.getEntities(Contact.class);
-
-		for (Object object: persistenceEntities) {
-			Contact contact = (Contact) object;
-			contacts.add(contact);
+		for (Object object: persistence.getEntities(Contact.class)) {
+			contacts.add((Contact) object);
 		}
 	}
 
@@ -112,13 +108,8 @@ public class ContactsActor extends Actor {
 				case WRITE_CONTACTS:
 					for (Object object : data) {
 						Contact contact = (Contact) object;
-						this.contacts.replace(contact);
-						if (persistence.getEntity(contact.getPersistenceID(), Contact.class) == null) {
-							persistence.persistEntity(contact.getPersistenceID(), contact);
-						}
-						else {
-							persistence.updateEntity(contact.getPersistenceID(), contact);
-						}
+						this.contacts.add(contact);
+						persistence.updateOrPersistEntity(contact);
 						eventEmitter.emit(EventNameConstants.EVENT_CONTACT_ADDED, contact);
 					}
 					break;

--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -45,7 +45,7 @@ public class ContactsActor extends Actor {
 		this.eventEmitter = EventEmitter.getDefault();
 
 		for (Object object: persistence.getEntities(Contact.class)) {
-			contacts.add((Contact) object);
+			contacts.put((Contact) object);
 		}
 	}
 
@@ -108,7 +108,7 @@ public class ContactsActor extends Actor {
 				case WRITE_CONTACTS:
 					for (Object object : data) {
 						Contact contact = (Contact) object;
-						this.contacts.add(contact);
+						this.contacts.put(contact);
 						persistence.updateOrPersistEntity(contact);
 						eventEmitter.emit(EventNameConstants.EVENT_CONTACT_ADDED, contact);
 					}

--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -124,6 +124,5 @@ public class ContactsActor extends Actor {
 					break;
 			}
 		}
-		stop();
 	}
 }

--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -6,18 +6,26 @@ import java.util.ArrayList;
 import de.qabel.ackack.Actor;
 import de.qabel.ackack.MessageInfo;
 import de.qabel.ackack.Responsible;
+import de.qabel.ackack.event.EventEmitter;
+import de.qabel.core.EventNameConstants;
 
 /**
  * Actor which handles the access to contacts of Qabel.
+ * Emits EVENT_CONTACT_ADDED and EVENT_CONTACT_REMOVED.
  *
  */
 public class ContactsActor extends Actor {
 	private static ContactsActor defaultContactsActor = null;
-	private Contacts contacts;
+	private EventEmitter eventEmitter;
+	private final Contacts contacts;
 
-	static ContactsActor getDefault() {
+	/**
+	 * Get the default ContactActor. Uses the default EventEmitter.
+	 * @return default ContactActor
+	 */
+	public static ContactsActor getDefault() {
 		if (defaultContactsActor == null) {
-			defaultContactsActor = new ContactsActor(new Contacts());
+			defaultContactsActor = new ContactsActor(new Contacts(), EventEmitter.getDefault());
 		}
 		return defaultContactsActor;
 	}
@@ -26,8 +34,23 @@ public class ContactsActor extends Actor {
 	private static final String RETRIEVE_CONTACTS = "retrieveContacts";
 	private static final String REMOVE_CONTACTS = "removeContacts";
 
+	/**
+	 * Creates a new ContactActor with given contacts. Uses the default EventEmitter.
+	 * @param contacts Contacts to use in ContactActor
+	 */
 	public ContactsActor (Contacts contacts) {
 		this.contacts = contacts;
+		this.eventEmitter = EventEmitter.getDefault();
+	}
+
+	/**
+	 * Creates a new ContactActor with given contacts and EventEmitter.
+	 * @param contacts Contacts to use in ContactActor
+	 * @param eventEmitter EventEmitter to emit events from
+	 */
+	public ContactsActor(Contacts contacts, EventEmitter eventEmitter) {
+		this(contacts);
+		this.eventEmitter = eventEmitter;
 	}
 
 	/**
@@ -70,33 +93,36 @@ public class ContactsActor extends Actor {
 
 	@Override
 	protected void react(MessageInfo info, Object... data) {
-		switch(info.getType()) {
-		case WRITE_CONTACTS:
-			Contact contact;
-			for (int i = data.length-1; i>=0; i--) {
-				contact = (Contact) data[i];
-				this.contacts.replace(contact);
+		synchronized (contacts) {
+			switch (info.getType()) {
+				case WRITE_CONTACTS:
+					Contact contact;
+					for (int i = data.length - 1; i >= 0; i--) {
+						contact = (Contact) data[i];
+						this.contacts.replace(contact);
+						eventEmitter.emit(EventNameConstants.EVENT_CONTACT_ADDED, contact);
+					}
+					break;
+				case RETRIEVE_CONTACTS:
+					Contact[] contactsArray;
+					if(data.length > 0) {
+						ArrayList<Contact> contactsList = new ArrayList<Contact>();
+						for (int i = data.length - 1; i >= 0; i--) {
+							contactsList.add(this.contacts.getByKeyIdentifier((String) data[i]));
+						}
+						contactsArray = (Contact[]) contactsList.toArray(new Contact[0]);
+					} else {
+						contactsArray = this.contacts.getContacts().toArray(new Contact[0]);
+					}
+					info.response((Serializable[]) contactsArray);
+					break;
+				case REMOVE_CONTACTS:
+					for (int i = data.length - 1; i >= 0; i--) {
+						this.contacts.remove(data[i].toString());
+						eventEmitter.emit(EventNameConstants.EVENT_CONTACT_REMOVED, data[i].toString());
+					}
+					break;
 			}
-			break;
-		case RETRIEVE_CONTACTS:
-			Contact[] contactsArray;
-			if(data.length > 0) {
-				ArrayList<Contact> contactsList = new ArrayList<Contact>();
-				for(int i = data.length-1; i >= 0; i--){
-					contactsList.add(this.contacts.getByKeyIdentifier((String) data[i]));
-				}
-				contactsArray = (Contact[]) contactsList.toArray(new Contact[0]);
-			}
-			else {
-				contactsArray = this.contacts.getContacts().toArray(new Contact[0]);
-			}
-			info.response((Serializable[]) contactsArray);
-			break;
-		case REMOVE_CONTACTS:
-			for (int i = data.length-1; i>=0; i--) {
-				this.contacts.remove(data[i].toString());
-			}
-			break;
 		}
 		stop();
 	}

--- a/src/main/java/de/qabel/core/config/ContactsTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/ContactsTypeAdapter.java
@@ -39,7 +39,7 @@ public class ContactsTypeAdapter extends TypeAdapter<Contacts> {
 		in.beginArray();
 		while(in.hasNext()) {
 			contact = adapter.read(in);
-			contacts.add(contact);
+			contacts.put(contact);
 		}
 		in.endArray();
 		

--- a/src/main/java/de/qabel/core/config/DropServers.java
+++ b/src/main/java/de/qabel/core/config/DropServers.java
@@ -1,8 +1,6 @@
 package de.qabel.core.config;
 
-import java.util.Collections;
-import java.util.Set;
-import java.util.HashSet;
+import java.util.*;
 
 /**
  * https://github.com/Qabel/qabel-doc/wiki/Qabel-Client-Configuration#drop-servers
@@ -15,22 +13,25 @@ public class DropServers {
 	 *           dropServers        &gt;       dropServer
 	 * </pre>
 	 */
-	private final Set<DropServer> dropServers = new HashSet<DropServer>();
+	private final Map<String, DropServer> dropServers = new HashMap<>();
 
 	/**
 	 * @return Returns unmodifiable set of contained drop servers
 	 */
 	public Set<DropServer> getDropServers() {
-		return Collections.unmodifiableSet(this.dropServers);
+		return Collections.unmodifiableSet(new HashSet<>(this.dropServers.values()));
 	}
 	
 	/**
-	 * Adds a drop server.
-	 * @param dropServer DropServer to add.
-	 * @return true if successfully added, false if already contained.
+	 * Adds or updates a drop server.
+	 * @param dropServer DropServer to add or update.
+	 * @return True if newly added, false if updated
 	 */
 	public boolean add(DropServer dropServer) {
-		return this.dropServers.add(dropServer);
+		if (this.dropServers.put(dropServer.getPersistenceID(), dropServer) == null) {
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -39,12 +40,10 @@ public class DropServers {
 	 * @return true if dropServer was contained in list, false if not.
 	 */
 	public boolean remove(DropServer dropServer) {
-		return this.dropServers.remove(dropServer);
-	}
-
-	public boolean update(DropServer dropServer) {
-		this.remove(dropServer);
-		return this.add(dropServer);
+		if (this.dropServers.remove(dropServer.getPersistenceID()) == null) {
+			return false;
+		}
+		return true;
 	}
 
 	@Override

--- a/src/main/java/de/qabel/core/config/DropServers.java
+++ b/src/main/java/de/qabel/core/config/DropServers.java
@@ -23,11 +23,11 @@ public class DropServers {
 	}
 	
 	/**
-	 * Adds or updates a drop server.
-	 * @param dropServer DropServer to add or update.
+	 * Put a drop server.
+	 * @param dropServer DropServer to put.
 	 * @return True if newly added, false if updated
 	 */
-	public boolean add(DropServer dropServer) {
+	public boolean put(DropServer dropServer) {
 		if (this.dropServers.put(dropServer.getPersistenceID(), dropServer) == null) {
 			return true;
 		}

--- a/src/main/java/de/qabel/core/config/DropServersTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/DropServersTypeAdapter.java
@@ -39,7 +39,7 @@ public class DropServersTypeAdapter extends TypeAdapter<DropServers> {
 		in.beginArray();
 		while(in.hasNext()) {
 			dropServer = adapter.read(in);
-			dropServers.add(dropServer);
+			dropServers.put(dropServer);
 		}
 		in.endArray();
 		

--- a/src/main/java/de/qabel/core/config/Entity.java
+++ b/src/main/java/de/qabel/core/config/Entity.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.drop.DropURL;
@@ -15,9 +14,7 @@ import de.qabel.core.drop.DropURL;
  */
 public abstract class Entity extends SyncSettingItem {
 	private static final long serialVersionUID = 570661846263644501L;
-	private static final Set<UUID> uuids = new HashSet<>();
 
-	private UUID persistenceID;
 	private final Set<DropURL> dropUrls;
 	private final Set<AbstractModuleSettings> moduleSettings = new HashSet<AbstractModuleSettings>(); // TODO: Will
 
@@ -27,7 +24,6 @@ public abstract class Entity extends SyncSettingItem {
 		} else {
 			this.dropUrls = new HashSet<>();
 		}
-		this.persistenceID = genPersistenceID();
 	}
 	
 	abstract public QblECPublicKey getEcPublicKey();
@@ -41,8 +37,6 @@ public abstract class Entity extends SyncSettingItem {
 		return this.getEcPublicKey().getReadableKeyIdentifier();
 	}
 
-	public String getPersistenceID() { return persistenceID.toString(); }
-
 	public Set<DropURL> getDropUrls() {
 		return Collections.unmodifiableSet(dropUrls);
 	}
@@ -53,19 +47,6 @@ public abstract class Entity extends SyncSettingItem {
 
 	public Set<AbstractModuleSettings> getModuleSettings() {
 		return moduleSettings;
-	}
-
-	/**
-	 * Generated a random UUID for persistent storage. It ensures that Entities are using a unique UUID.
-	 * @return Unique UUID
-	 */
-	private UUID genPersistenceID(){
-		UUID uuid = UUID.randomUUID();
-		while (uuids.contains(uuid)) {
-			uuid = UUID.randomUUID();
-		}
-		uuids.add(uuid);
-		return uuid;
 	}
 
 	@Override

--- a/src/main/java/de/qabel/core/config/EntityMap.java
+++ b/src/main/java/de/qabel/core/config/EntityMap.java
@@ -22,7 +22,7 @@ abstract public class EntityMap<T extends Entity> implements Serializable {
 		return Collections.unmodifiableSet(new HashSet<>(entities.values()));
 	}
 
-	public synchronized boolean add(T entity) {
+	public synchronized boolean put(T entity) {
 		if (this.entities.put(entity.getKeyIdentifier(), entity) == null) {
 			return false;
 		}

--- a/src/main/java/de/qabel/core/config/EntityMap.java
+++ b/src/main/java/de/qabel/core/config/EntityMap.java
@@ -1,14 +1,10 @@
 package de.qabel.core.config;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
- * EntityMaps provide funcionality to lookup an Enity based
+ * EntityMaps provide functionality to lookup an Entity based
  * on its key identifier.
  * 
  * @see Entity
@@ -27,18 +23,10 @@ abstract public class EntityMap<T extends Entity> implements Serializable {
 	}
 
 	public synchronized boolean add(T entity) {
-		if (this.entities.containsKey(entity.getKeyIdentifier())) {
+		if (this.entities.put(entity.getKeyIdentifier(), entity) == null) {
 			return false;
 		}
-		else {
-			this.entities.put(entity.getKeyIdentifier(), entity);
-			return true;
-		}
-	}
-
-	public synchronized boolean replace(T entity) {
-		this.remove(entity);
-		return this.add(entity);
+		return true;
 	}
 
 	public synchronized boolean remove(T entity) {

--- a/src/main/java/de/qabel/core/config/EntityMap.java
+++ b/src/main/java/de/qabel/core/config/EntityMap.java
@@ -15,18 +15,18 @@ import java.util.Set;
  */
 abstract public class EntityMap<T extends Entity> implements Serializable {
 	private static final long serialVersionUID = -8004819460313825206L;
-	private final Map<String, T> entities = new HashMap<>();
+	private final Map<String, T> entities = Collections.synchronizedMap(new HashMap<String, T>());
 
 	/**
 	 * Returns unmodifiable set of contained contacts
 	 * 
 	 * @return Set<Contact>
 	 */
-	public Set<T> getEntities() {
+	public synchronized Set<T> getEntities() {
 		return Collections.unmodifiableSet(new HashSet<>(entities.values()));
 	}
 
-	public boolean add(T entity) {
+	public synchronized boolean add(T entity) {
 		if (this.entities.containsKey(entity.getKeyIdentifier())) {
 			return false;
 		}
@@ -36,16 +36,16 @@ abstract public class EntityMap<T extends Entity> implements Serializable {
 		}
 	}
 
-	public boolean replace(T entity) {
+	public synchronized boolean replace(T entity) {
 		this.remove(entity);
 		return this.add(entity);
 	}
 
-	public boolean remove(T entity) {
+	public synchronized boolean remove(T entity) {
 		return (entity != null && this.entities.remove(entity.getKeyIdentifier()) != null);
 	}
 
-	public boolean remove(String keyIdentifier) {
+	public synchronized boolean remove(String keyIdentifier) {
 		return (keyIdentifier != null && this.entities.remove(keyIdentifier) != null);
 	}
 
@@ -54,7 +54,7 @@ abstract public class EntityMap<T extends Entity> implements Serializable {
 	 * @param keyIdentifier
 	 * @return entity to which the key identifier is mapped or null if there is no mapping for this key identifier
 	 */
-	public T getByKeyIdentifier(String keyIdentifier) {
+	public synchronized T getByKeyIdentifier(String keyIdentifier) {
 		return this.entities.get(keyIdentifier);
 	}
 

--- a/src/main/java/de/qabel/core/config/IdentitiesTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/IdentitiesTypeAdapter.java
@@ -45,7 +45,7 @@ public class IdentitiesTypeAdapter extends TypeAdapter<Identities> {
 		in.beginArray();
 		while(in.hasNext()) {
 			identity = adapter.read(in);
-			identities.add(identity);
+			identities.put(identity);
 		}
 		in.endArray();
 		

--- a/src/main/java/de/qabel/core/config/LocalSettings.java
+++ b/src/main/java/de/qabel/core/config/LocalSettings.java
@@ -14,7 +14,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * https://github.com/Qabel/qabel-doc/wiki/Qabel-Client-Configuration#local-settings
  */
-public class LocalSettings extends Persistable implements Serializable {
+public class LocalSettings extends Persistable {
 	private static final long serialVersionUID = 2524933619654534515L;
 	private Set<LocaleModuleSettings> localeModuleSettings;
 	/**

--- a/src/main/java/de/qabel/core/config/LocalSettings.java
+++ b/src/main/java/de/qabel/core/config/LocalSettings.java
@@ -14,7 +14,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * https://github.com/Qabel/qabel-doc/wiki/Qabel-Client-Configuration#local-settings
  */
-public class LocalSettings implements Serializable {
+public class LocalSettings extends Persistable implements Serializable {
 	private static final long serialVersionUID = 2524933619654534515L;
 	private Set<LocaleModuleSettings> localeModuleSettings;
 	/**

--- a/src/main/java/de/qabel/core/config/Persistable.java
+++ b/src/main/java/de/qabel/core/config/Persistable.java
@@ -3,6 +3,10 @@ package de.qabel.core.config;
 import java.io.Serializable;
 import java.util.UUID;
 
+/**
+ * Persistable manages a unique persistence ID for objects that
+ * have to be persistable.
+ */
 public abstract class Persistable implements Serializable {
 
 	private UUID persistenceID;

--- a/src/main/java/de/qabel/core/config/Persistable.java
+++ b/src/main/java/de/qabel/core/config/Persistable.java
@@ -1,0 +1,32 @@
+package de.qabel.core.config;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public abstract class Persistable implements Serializable {
+
+	private static final Set<UUID> uuids = new HashSet<>();
+
+	private UUID persistenceID;
+
+	public Persistable() {
+		this.persistenceID = genPersistenceID();
+	}
+
+	public String getPersistenceID() { return persistenceID.toString(); }
+
+	/**
+	 * Generated a random UUID for persistent storage. It ensures that Entities are using a unique UUID.
+	 * @return Unique UUID
+	 */
+	private UUID genPersistenceID(){
+		UUID uuid = UUID.randomUUID();
+		while (uuids.contains(uuid)) {
+			uuid = UUID.randomUUID();
+		}
+		uuids.add(uuid);
+		return uuid;
+	}
+}

--- a/src/main/java/de/qabel/core/config/Persistable.java
+++ b/src/main/java/de/qabel/core/config/Persistable.java
@@ -1,13 +1,9 @@
 package de.qabel.core.config;
 
 import java.io.Serializable;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.UUID;
 
 public abstract class Persistable implements Serializable {
-
-	private static final Set<UUID> uuids = new HashSet<>();
 
 	private UUID persistenceID;
 
@@ -18,15 +14,10 @@ public abstract class Persistable implements Serializable {
 	public String getPersistenceID() { return persistenceID.toString(); }
 
 	/**
-	 * Generated a random UUID for persistent storage. It ensures that Entities are using a unique UUID.
+	 * Generated a random UUID for persistent storage.
 	 * @return Unique UUID
 	 */
 	private UUID genPersistenceID(){
-		UUID uuid = UUID.randomUUID();
-		while (uuids.contains(uuid)) {
-			uuid = UUID.randomUUID();
-		}
-		uuids.add(uuid);
-		return uuid;
+		return UUID.randomUUID();
 	}
 }

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 /**
  * Persistence defines methods to store encrypted entities into a database.
- * Entities has to be Serializable.
+ * Entities has to be Persistable.
  * Serialized data is encrypted with AES256 GCM, a nonce provided to the serialize/deserialize
  * methods and a key derived from the provides password with PBKDF2 and a salt.
  *

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -133,14 +133,14 @@ public abstract class Persistence<T> {
 	 * @param cls Class of the entity to receive
 	 * @return Stored entity or null if entity not found
 	 */
-	abstract public Object getEntity(String id, Class cls);
+	abstract public Persistable getEntity(String id, Class cls);
 
 	/**
 	 * Get all entities of the provides Class
 	 * @param cls Class to get all stored entities for
 	 * @return List of stored entities
 	 */
-	abstract public List<Object> getEntities(Class cls);
+	abstract public List<Persistable> getEntities(Class cls);
 
 	/**
 	 * Drops the table for the provided Class

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -100,19 +100,18 @@ public abstract class Persistence<T> {
 
 	/**
 	 * Persists an entity
-	 * @param id ID for entity storage
 	 * @param object Entity to persist
 	 * @return Result of the operation
 	 */
-	abstract public boolean persistEntity(String id, Serializable object);
+	abstract public boolean persistEntity(Persistable object);
 
 	/**
 	 * Updates a previously stored entity
-	 * @param id ID of the stored entity
 	 * @param object Entity to replace stored entity with
 	 * @return Result of the operation
 	 */
-	abstract public boolean updateEntity(String id, Serializable object);
+	abstract public boolean updateEntity(Persistable object);
+
 
 	/**
 	 * Removes a persisted entity

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -110,8 +110,14 @@ public abstract class Persistence<T> {
 	 * @param object Entity to replace stored entity with
 	 * @return Result of the operation
 	 */
-	abstract public boolean updateEntity(Persistable object);
+	abstract boolean updateEntity(Persistable object);
 
+	/**
+	 * Updates a previously stored entity or persist a new entity
+	 * @param object Entity to replace stored entity with
+	 * @return Result of the operation
+	 */
+	abstract public boolean updateOrPersistEntity(Persistable object);
 
 	/**
 	 * Removes a persisted entity

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -329,21 +329,21 @@ public class SQLitePersistence extends Persistence<String> {
 	}
 
 	@Override
-	public Object getEntity(String id, Class cls) {
+	public Persistable getEntity(String id, Class cls) {
 		if (id == null || cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
 		if (id.length() == 0) {
 			throw new IllegalArgumentException("ID cannot be empty!");
 		}
-		Object object = null;
+		Persistable object = null;
 		String sql = "SELECT BLOB, NONCE FROM " +
 				"\"" + cls.getCanonicalName() + "\"" +
 				" WHERE ID = ?";
 		try (PreparedStatement statement = c.prepareStatement(sql)){
 			statement.setString(1, id);
 			try (ResultSet rs = statement.executeQuery()) {
-				object = deserialize(id, rs.getBytes("BLOB"), rs.getBytes("NONCE"));
+				object = (Persistable) deserialize(id, rs.getBytes("BLOB"), rs.getBytes("NONCE"));
 			}
 		} catch (SQLException | IllegalArgumentException e) {
 			logger.error("Cannot get entity!", e);
@@ -352,17 +352,17 @@ public class SQLitePersistence extends Persistence<String> {
 	}
 
 	@Override
-	public List<Object> getEntities(Class cls) {
+	public List<Persistable> getEntities(Class cls) {
 		if (cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
-		List<Object> objects = new ArrayList<>();
+		List<Persistable> objects = new ArrayList<>();
 		String sql = "SELECT ID, BLOB, NONCE FROM " +
 				"\"" + cls.getCanonicalName() + "\"";
 		try (Statement statement = c.createStatement()){
 			try (ResultSet rs = statement.executeQuery(sql)) {
 				while (rs.next()) {
-					objects.add(deserialize(new String(rs.getBytes("ID")), rs.getBytes("BLOB"), rs.getBytes("NONCE")));
+					objects.add((Persistable) deserialize(new String(rs.getBytes("ID")), rs.getBytes("BLOB"), rs.getBytes("NONCE")));
 				}
 			}
 		} catch (SQLException | IllegalArgumentException e) {

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -277,7 +277,7 @@ public class SQLitePersistence extends Persistence<String> {
 	}
 
 	@Override
-	public boolean updateEntity(Persistable object) {
+	boolean updateEntity(Persistable object) {
 		if (object == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
@@ -295,6 +295,16 @@ public class SQLitePersistence extends Persistence<String> {
 			return false;
 		}
 		return true;
+	}
+
+	@Override
+	public boolean updateOrPersistEntity(Persistable object) {
+		if (getEntity(object.getPersistenceID(), object.getClass()) == null) {
+			return persistEntity(object);
+		}
+		else {
+			return updateEntity(object);
+		}
 	}
 
 	@Override

--- a/src/main/java/de/qabel/core/config/StorageServers.java
+++ b/src/main/java/de/qabel/core/config/StorageServers.java
@@ -26,11 +26,11 @@ public class StorageServers {
 	}
 	
 	/**
-	 * Adds a storage server
-	 * @param storageServer StorageServer to add.
+	 * Put a storage server
+	 * @param storageServer StorageServer to put.
 	 * @return true if newly added, false if updated
 	 */
-	public boolean add(StorageServer storageServer) {
+	public boolean put(StorageServer storageServer) {
 		if (this.storageServers.put(storageServer.getUrl().toString(), storageServer) == null) {
 			return true;
 		}

--- a/src/main/java/de/qabel/core/config/StorageServers.java
+++ b/src/main/java/de/qabel/core/config/StorageServers.java
@@ -11,14 +11,14 @@ import java.util.HashSet;
  */
 public class StorageServers {
 
-	private final Map<String,StorageServer> storageServers = new HashMap<String,StorageServer>();
+	private final Map<String, StorageServer> storageServers = new HashMap<>();
 
 	/**
 	 * Returns an unmodifiable set of contained storage servers
 	 * @return Set<StorageServer>
 	 */
 	public Set<StorageServer> getStorageServers() {
-		return Collections.unmodifiableSet(new HashSet<StorageServer>(this.storageServers.values()));
+		return Collections.unmodifiableSet(new HashSet<>(this.storageServers.values()));
 	}
 	
 	protected StorageServer getStorageServerByUrl(String serverUrl) {
@@ -28,14 +28,13 @@ public class StorageServers {
 	/**
 	 * Adds a storage server
 	 * @param storageServer StorageServer to add.
-	 * @return true if successfully added, false if already contained
+	 * @return true if newly added, false if updated
 	 */
 	public boolean add(StorageServer storageServer) {
-		if (this.storageServers.containsValue(storageServer)) {
-			return false;
+		if (this.storageServers.put(storageServer.getUrl().toString(), storageServer) == null) {
+			return true;
 		}
-		this.storageServers.put(storageServer.getUrl().toString(), storageServer);
-		return true;
+		return false;
 	}
 
 	/**
@@ -46,11 +45,6 @@ public class StorageServers {
 	public boolean remove(StorageServer storageServer) {
 		return storageServer != null
 				&& this.storageServers.remove(storageServer.getUrl().toString()) != null;
-	}
-
-	public boolean update(StorageServer storageServer) {
-		this.remove(storageServer);
-		return this.add(storageServer);
 	}
 
 	@Override

--- a/src/main/java/de/qabel/core/config/StorageServersTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/StorageServersTypeAdapter.java
@@ -39,7 +39,7 @@ public class StorageServersTypeAdapter extends TypeAdapter<StorageServers> {
 		in.beginArray();
 		while(in.hasNext()) {
 			storageServer = adapter.read(in);
-			storageServers.add(storageServer);
+			storageServers.put(storageServer);
 		}
 		in.endArray();
 		

--- a/src/main/java/de/qabel/core/config/StorageVolumes.java
+++ b/src/main/java/de/qabel/core/config/StorageVolumes.java
@@ -1,31 +1,32 @@
 package de.qabel.core.config;
 
-import java.util.Collections;
-import java.util.Set;
-import java.util.HashSet;
+import java.util.*;
 
 /**
  * https://github.com/Qabel/qabel-doc/wiki/Qabel-Client-Configuration#storage-volumes
  */
 public class StorageVolumes {
 
-	private final Set<StorageVolume> storageVolumes = new HashSet<StorageVolume>();
+	private final Map<String, StorageVolume> storageVolumes = new HashMap<>();
 
 	/**
 	 * Returns an unmodifiable set of contained storage volumes
 	 * @return Set<StorageVolume>
 	 */
 	public Set<StorageVolume> getStorageVolumes() {
-		return Collections.unmodifiableSet(this.storageVolumes);
+		return Collections.unmodifiableSet(new HashSet<>(this.storageVolumes.values()));
 	}
 	
 	/**
 	 * Adds a storage volume
 	 * @param storageVolume StorageVolume to add.
-	 * @return true if successfully added, false if already contained
+	 * @return true if newly added, false if updated
 	 */
 	public boolean add(StorageVolume storageVolume) {
-		return this.storageVolumes.add(storageVolume);
+		if (this.storageVolumes.put(storageVolume.getPersistenceID(), storageVolume) == null) {
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -34,12 +35,10 @@ public class StorageVolumes {
 	 * @return true if storageVolume was contained in list, false if not
 	 */
 	public boolean remove(StorageVolume storageVolume) {
-		return this.storageVolumes.remove(storageVolume);
-	}
-
-	public boolean update(StorageVolume storageVolume) {
-		this.remove(storageVolume);
-		return this.add(storageVolume);
+		if(this.storageVolumes.remove(storageVolume.getPersistenceID()) == null) {
+			return false;
+		}
+		return true;
 	}
 
 	@Override

--- a/src/main/java/de/qabel/core/config/StorageVolumes.java
+++ b/src/main/java/de/qabel/core/config/StorageVolumes.java
@@ -18,11 +18,11 @@ public class StorageVolumes {
 	}
 	
 	/**
-	 * Adds a storage volume
-	 * @param storageVolume StorageVolume to add.
+	 * Put a storage volume
+	 * @param storageVolume StorageVolume to put.
 	 * @return true if newly added, false if updated
 	 */
-	public boolean add(StorageVolume storageVolume) {
+	public boolean put(StorageVolume storageVolume) {
 		if (this.storageVolumes.put(storageVolume.getPersistenceID(), storageVolume) == null) {
 			return true;
 		}

--- a/src/main/java/de/qabel/core/config/StorageVolumesTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/StorageVolumesTypeAdapter.java
@@ -36,7 +36,7 @@ public class StorageVolumesTypeAdapter extends TypeAdapter<StorageVolumes> {
 		in.beginArray();
 		while(in.hasNext()) {
 			storageVolume = adapter.read(in);
-			storageVolumes.add(storageVolume);
+			storageVolumes.put(storageVolume);
 		}
 		in.endArray();
 		

--- a/src/main/java/de/qabel/core/config/SyncSettingItem.java
+++ b/src/main/java/de/qabel/core/config/SyncSettingItem.java
@@ -6,7 +6,7 @@ import java.util.Date;
 /**
  * Class SyncSettingItem: Class to store common setting for synced item
  */
-public class SyncSettingItem extends Persistable implements Serializable {
+public class SyncSettingItem extends Persistable {
 	private static final long serialVersionUID = 1798935486715989955L;
 	private int id = 0;
     private long created = new Date().getTime();

--- a/src/main/java/de/qabel/core/config/SyncSettingItem.java
+++ b/src/main/java/de/qabel/core/config/SyncSettingItem.java
@@ -6,7 +6,7 @@ import java.util.Date;
 /**
  * Class SyncSettingItem: Class to store common setting for synced item
  */
-public class SyncSettingItem implements Serializable {
+public class SyncSettingItem extends Persistable implements Serializable {
 	private static final long serialVersionUID = 1798935486715989955L;
 	private int id = 0;
     private long created = new Date().getTime();

--- a/src/main/java/de/qabel/core/config/SyncedSettingsTypeAdapter.java
+++ b/src/main/java/de/qabel/core/config/SyncedSettingsTypeAdapter.java
@@ -142,7 +142,7 @@ public class SyncedSettingsTypeAdapter extends TypeAdapter<SyncedSettings> {
 			storageVolumes.remove(volume);
 			volume.setStorageServer(
 					storageServers.getStorageServerByUrl(volume.getServerUrlString()));
-			storageVolumes.add(volume);
+			storageVolumes.put(volume);
 		}
 		
 		syncedSettings = new SyncedSettings();

--- a/src/main/java/de/qabel/core/drop/DropActor.java
+++ b/src/main/java/de/qabel/core/drop/DropActor.java
@@ -73,7 +73,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 			public void onResponse(Serializable... data) {
 				ArrayList<Contact> receivedContacts = new ArrayList<>(Arrays.asList((Contact[]) data));
 				for (Contact c : receivedContacts) {
-					mContacts.add(c);
+					mContacts.put(c);
 				}
 			}
 		});
@@ -84,7 +84,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 			public void onResponse(Serializable... data) {
 				ArrayList<Identity> receivedIdentities = new ArrayList<>(Arrays.asList((Identity[]) data));
 				for (Identity i : receivedIdentities) {
-					mIdentities.add(i);
+					mIdentities.put(i);
 				}
 			}
 		});
@@ -94,7 +94,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 			public void onResponse(Serializable... data) {
 				ArrayList<DropServer> receivedDropServer = new ArrayList<>(Arrays.asList((DropServer[]) data));
 				for (DropServer s : receivedDropServer) {
-					mDropServers.add(s);
+					mDropServers.put(s);
 				}
 			}
 		});
@@ -347,7 +347,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 				break;
 			case EventNameConstants.EVENT_CONTACT_ADDED:
 				if (data[0] instanceof Contact) {
-					mContacts.add((Contact) data[0]);
+					mContacts.put((Contact) data[0]);
 				}
 				break;
 			case EventNameConstants.EVENT_CONTACT_REMOVED:
@@ -357,7 +357,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 				break;
 			case EventNameConstants.EVENT_IDENTITY_ADDED:
 				if (data[0] instanceof Identity) {
-					mIdentities.add((Identity) data[0]);
+					mIdentities.put((Identity) data[0]);
 				}
 				break;
 			case EventNameConstants.EVENT_IDENTITY_REMOVED:
@@ -367,7 +367,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 				break;
 			case EventNameConstants.EVENT_DROPSERVER_ADDED:
 				if (data[0] instanceof DropServer) {
-					mDropServers.add((DropServer) data[0]);
+					mDropServers.put((DropServer) data[0]);
 				}
 				break;
 			case EventNameConstants.EVENT_DROPSERVER_REMOVED:

--- a/src/main/java/de/qabel/core/drop/DropActor.java
+++ b/src/main/java/de/qabel/core/drop/DropActor.java
@@ -22,6 +22,11 @@ import de.qabel.core.http.HTTPResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * DropActor is registered to Contact, Identity and DropServer added and removed events. On instantiation all Contacts,
+ * Identities and DropServers are loaded from the according actors and stored in member variables. The registered
+ * event listeners allows the DropActor to receive and store changes to these resources.
+ */
 public class DropActor extends EventActor implements de.qabel.ackack.event.EventListener {
 	private final static Logger logger = LogManager.getLogger(DropActor.class.getName());
 

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -90,13 +90,6 @@ public class MultiPartCryptoTest {
         this.sendMessage();
 		this.sendUnwantedMessage();
 
-
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-
         DropMessage<TestObject> msg = dropController.retrieve();
 
         assertEquals("Test", msg.getData().getStr());
@@ -112,13 +105,6 @@ public class MultiPartCryptoTest {
         this.sendMessage();
 		this.sendUnwantedMessage();
         this.sendMessage();
-
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-
 
         DropMessage<TestObject> msg = dropController.retrieve();
         assertEquals("Test", msg.getData().getStr());

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -27,6 +27,8 @@ public class MultiPartCryptoTest {
     private Contacts contacts;
     private Identities identities;
     private DropServers servers;
+    private Thread contactsActorThread;
+
 
     static class TestObject extends ModelObject {
         public TestObject() { }
@@ -59,7 +61,9 @@ public class MultiPartCryptoTest {
 
     @Before
     public void setUp() throws InvalidKeyException, MalformedURLException, QblDropInvalidURL, InterruptedException {
-        emitter = new EventEmitter();
+        contactsActorThread = new Thread(ContactsActor.getDefault());
+        contactsActorThread.start();
+        emitter = EventEmitter.getDefault();
         dropController = new DropCommunicatorUtil(emitter);
 
         loadContactsAndIdentities();

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -150,12 +150,12 @@ public class MultiPartCryptoTest {
         alicesContact.addDrop(new DropURL("http://localhost:6000/12345678901234567890123456789012345678alice"));
 
         contacts = new Contacts();
-        contacts.add(alicesContact);
-        contacts.add(bobsContact);
+        contacts.put(alicesContact);
+        contacts.put(bobsContact);
 
         identities = new Identities();
-		identities.add(alice);
-		identities.add(bob);
+		identities.put(alice);
+		identities.put(bob);
     }
 
     private void loadDropServers() throws MalformedURLException {
@@ -167,8 +167,8 @@ public class MultiPartCryptoTest {
         DropServer bobsServer = new DropServer();
         bobsServer.setUrl(new URL("http://localhost:6000/1234567890123456789012345678901234567890bob"));
 
-        servers.add(alicesServer);
-        servers.add(bobsServer);
+        servers.put(alicesServer);
+        servers.put(bobsServer);
 
     }
 

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -30,6 +30,7 @@ public class MultiPartCryptoTest {
     private Identities identities;
     private DropServers servers;
     private Thread contactsActorThread;
+    private Thread configActorThread;
 
 
     static class TestObject extends ModelObject {
@@ -66,6 +67,8 @@ public class MultiPartCryptoTest {
         Persistence.setPassword(encryptionPassword);
         contactsActorThread = new Thread(ContactsActor.getDefault());
         contactsActorThread.start();
+		configActorThread = new Thread(ConfigActor.getDefault());
+		configActorThread.start();
         emitter = EventEmitter.getDefault();
         dropController = new DropCommunicatorUtil(emitter);
 

--- a/src/test/java/de/qabel/core/config/AccountsEquivalentTestFactory.java
+++ b/src/test/java/de/qabel/core/config/AccountsEquivalentTestFactory.java
@@ -21,8 +21,8 @@ class AccountsEquivalentTestFactory implements EquivalentFactory<Accounts>{
 	public Accounts create() {
 		Accounts accounts = new Accounts();
 
-		accounts.add(a);
-		accounts.add(b);
+		accounts.put(a);
+		accounts.put(b);
 
 		return accounts;
 	}

--- a/src/test/java/de/qabel/core/config/AccountsTestFactory.java
+++ b/src/test/java/de/qabel/core/config/AccountsTestFactory.java
@@ -17,8 +17,8 @@ class AccountsTestFactory implements Factory<Accounts>{
 		Account a = new Account("provider" + i, "user" + i, "auth" + i++);
 		Account b = new Account("provider" + i, "user" + i, "auth" + i++);
 
-		accounts.add(a);
-		accounts.add(b);
+		accounts.put(a);
+		accounts.put(b);
 		
 		return accounts;
 	}

--- a/src/test/java/de/qabel/core/config/ConfigEqualsTest.java
+++ b/src/test/java/de/qabel/core/config/ConfigEqualsTest.java
@@ -33,14 +33,14 @@ public class ConfigEqualsTest {
 		Accounts b = new Accounts();
 		Accounts c = new Accounts();
 
-		a.add(a1);
-		a.add(a2);
+		a.put(a1);
+		a.put(a2);
 
-		b.add(a1);
-		b.add(a2);
+		b.put(a1);
+		b.put(a2);
 
-		c.add(a1);
-		c.add(c1);
+		c.put(a1);
+		c.put(c1);
 
 		assertEquals(a, b);
 		assertNotEquals(a, c);
@@ -62,14 +62,14 @@ public class ConfigEqualsTest {
 		Contacts b = new Contacts();
 		Contacts c = new Contacts();
 
-		a.add(a1);
-		a.add(a2);
+		a.put(a1);
+		a.put(a2);
 
-		b.add(a1);
-		b.add(a2);
+		b.put(a1);
+		b.put(a2);
 
-		c.add(a1);
-		c.add(c1);
+		c.put(a1);
+		c.put(c1);
 
 		assertEquals(a, b);
 		assertNotEquals(a, c);
@@ -91,14 +91,14 @@ public class ConfigEqualsTest {
 		DropServers b = new DropServers();
 		DropServers c = new DropServers();
 
-		a.add(a1);
-		a.add(a2);
+		a.put(a1);
+		a.put(a2);
 
-		b.add(a1);
-		b.add(a2);
+		b.put(a1);
+		b.put(a2);
 
-		c.add(a1);
-		c.add(c1);
+		c.put(a1);
+		c.put(c1);
 
 		assertEquals(a, b);
 		assertNotEquals(a, c);
@@ -120,14 +120,14 @@ public class ConfigEqualsTest {
 		Identities b = new Identities();
 		Identities c = new Identities();
 
-		a.add(a1);
-		a.add(a2);
+		a.put(a1);
+		a.put(a2);
 
-		b.add(a1);
-		b.add(a2);
+		b.put(a1);
+		b.put(a2);
 
-		c.add(a1);
-		c.add(c1);
+		c.put(a1);
+		c.put(c1);
 
 		assertEquals(a, b);
 		assertNotEquals(a, c);
@@ -149,14 +149,14 @@ public class ConfigEqualsTest {
 		StorageServers b = new StorageServers();
 		StorageServers c = new StorageServers();
 
-		a.add(a1);
-		a.add(a2);
+		a.put(a1);
+		a.put(a2);
 
-		b.add(a1);
-		b.add(a2);
+		b.put(a1);
+		b.put(a2);
 
-		c.add(a1);
-		c.add(c1);
+		c.put(a1);
+		c.put(c1);
 
 		assertEquals(a, b);
 		assertNotEquals(a, c);
@@ -177,14 +177,14 @@ public class ConfigEqualsTest {
 		StorageVolumes b = new StorageVolumes();
 		StorageVolumes c = new StorageVolumes();
 
-		a.add(a1);
-		a.add(a2);
+		a.put(a1);
+		a.put(a2);
 
-		b.add(a1);
-		b.add(a2);
+		b.put(a1);
+		b.put(a2);
 
-		c.add(a1);
-		c.add(c1);
+		c.put(a1);
+		c.put(c1);
 
 		assertEquals(a, b);
 		assertNotEquals(a, c);

--- a/src/test/java/de/qabel/core/config/ConfigSerializationTest.java
+++ b/src/test/java/de/qabel/core/config/ConfigSerializationTest.java
@@ -25,18 +25,18 @@ public class ConfigSerializationTest {
 	public void syncedSettingsTest() throws QblDropInvalidURL, IOException {
 		SyncedSettings syncedSettings = new SyncedSettings();
 		
-		//generate and add an "accounts" entry
+		//generate and put an "accounts" entry
 		Account account = new Account("provider", "user", "auth");
 		
-		syncedSettings.getAccounts().add(account);
+		syncedSettings.getAccounts().put(account);
 		
-		//generate and add an "drop_servers" entry
+		//generate and put an "drop_servers" entry
 		DropServer dropServer = new DropServer(new URL("https://drop.qabel.de/0123456789012345678901234567890123456789123"),"auth", true);
-		syncedSettings.getDropServers().add(dropServer);
+		syncedSettings.getDropServers().put(dropServer);
 		
 		//generate "identities" array
 		syncedSettings.setIdentities(new Identities());
-		//generate and add an "identities" entry
+		//generate and put an "identities" entry
 		QblECKeyPair key;
 		Collection<DropURL> drops; 
 		Identity identity;
@@ -45,14 +45,14 @@ public class ConfigSerializationTest {
 		drops = new ArrayList<DropURL>();
 		drops.add(new DropURL("https://inbox.qabel.de/123456789012345678901234567890123456789012c"));
 		identity = new Identity("alias", drops, key);
-		syncedSettings.getIdentities().add(identity);
+		syncedSettings.getIdentities().put(identity);
 		
-		//generate and add a "storage_servers" entry
+		//generate and put a "storage_servers" entry
 		StorageServer storageServer = new StorageServer(new URL("https://storage.qabel.de"), "auth");
-		syncedSettings.getStorageServers().add(storageServer);
+		syncedSettings.getStorageServers().put(storageServer);
 		
-		//generate and add a "storage_volumes" entry
-		syncedSettings.getStorageVolumes().add(new StorageVolume(storageServer, "publicIdentifier", "token", "revokeToken"));
+		//generate and put a "storage_volumes" entry
+		syncedSettings.getStorageVolumes().put(new StorageVolume(storageServer, "publicIdentifier", "token", "revokeToken"));
 		syncedSettings.getSyncedModuleSettings().add(new SyncedModuleSettings());
 
 		SyncedSettings deserializedSyncedSettings = SyncedSettings.fromJson(syncedSettings.toJson());

--- a/src/test/java/de/qabel/core/config/ContactsActorTest.java
+++ b/src/test/java/de/qabel/core/config/ContactsActorTest.java
@@ -27,6 +27,8 @@ public class ContactsActorTest {
 	public void setUp() {
 		contacts = contactsFactory.create();
 		contactsActor = new ContactsActor(contacts);
+		Thread contactsActorThread = new Thread(contactsActor);
+		contactsActorThread.start();
 	}
 
 	@Test
@@ -35,12 +37,9 @@ public class ContactsActorTest {
 		contacts.add(testContactRetrieveSingle);
 
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.retrieveContacts(testContactRetrieveSingle.getKeyIdentifier());
 		actorThread.join();
-		contactActorThread.join();
 		Assert.assertEquals(1, receivedContacts.size());
 		Assert.assertTrue(receivedContacts.contains(testContactRetrieveSingle));
 	}
@@ -53,13 +52,10 @@ public class ContactsActorTest {
 		contacts.add(testContactRetrieveMultiple2);
 
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.retrieveContacts(testContactRetrieveMultiple1.getKeyIdentifier(),
 				testContactRetrieveMultiple2.getKeyIdentifier());
 		actorThread.join();
-		contactActorThread.join();
 		Assert.assertTrue(receivedContacts.contains(testContactRetrieveMultiple1));
 		Assert.assertTrue(receivedContacts.contains(testContactRetrieveMultiple2));
 		Assert.assertEquals(2, receivedContacts.size());
@@ -68,12 +64,9 @@ public class ContactsActorTest {
 	@Test
 	public void retrieveAllContactsTest() throws InterruptedException {
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.retrieveContacts();
 		actorThread.join();
-		contactActorThread.join();
 
 		Assert.assertTrue(contacts.getContacts().containsAll(receivedContacts));
 		Assert.assertTrue(receivedContacts.containsAll(contacts.getContacts()));
@@ -84,12 +77,9 @@ public class ContactsActorTest {
 		Contact testContactAddSingle = contactFactory.create();
 
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.writeContacts(testContactAddSingle);
 		actorThread.join();
-		contactActorThread.join();
 		Assert.assertTrue(contacts.getContacts().contains(testContactAddSingle));
 	}
 
@@ -99,12 +89,9 @@ public class ContactsActorTest {
 		Contact testContactAddMulti2 = contactFactory.create();
 
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.writeContacts(testContactAddMulti1, testContactAddMulti2);
 		actorThread.join();
-		contactActorThread.join();
 		Assert.assertTrue(contacts.getContacts().contains(testContactAddMulti1));
 		Assert.assertTrue(contacts.getContacts().contains(testContactAddMulti2));
 	}
@@ -114,12 +101,9 @@ public class ContactsActorTest {
 		Contact testContactRemoveSingle = contactFactory.create();
 
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.removeContacts(testContactRemoveSingle.getKeyIdentifier());
 		actorThread.join();
-		contactActorThread.join();
 		Assert.assertFalse(contacts.getContacts().contains(testContactRemoveSingle));
 	}
 
@@ -131,13 +115,10 @@ public class ContactsActorTest {
 		contacts.add(testContactRemoveMultiple2);
 
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.removeContacts(testContactRemoveMultiple1.getKeyIdentifier(),
 				testContactRemoveMultiple2.getKeyIdentifier());
 		actorThread.join();
-		contactActorThread.join();
 		Assert.assertFalse(contacts.getContacts().contains(testContactRemoveMultiple1));
 		Assert.assertFalse(contacts.getContacts().contains(testContactRemoveMultiple2));
 	}
@@ -151,12 +132,9 @@ public class ContactsActorTest {
 
 		// Retrieve new test Contact via ContactsActor
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.retrieveContacts(testContactIdentifier);
 		actorThread.join();
-		contactActorThread.join();
 		Contact testContactChanged = receivedContacts.get(0);
 
 		// Create new test DropURL
@@ -171,7 +149,6 @@ public class ContactsActorTest {
 		testContactChanged.addDrop(testDropUrl);
 		testActor.writeContacts(testContactChanged);
 		actorThread.join();
-		contactActorThread.join();
 
 		// Get changed Contact from Contacts list
 		Contact writtenContact = contacts.getByKeyIdentifier(testContactIdentifier);
@@ -191,12 +168,9 @@ public class ContactsActorTest {
 
 		// Retrieve new test Contact via ContactsActor
 		Thread actorThread = new Thread(testActor);
-		Thread contactActorThread = new Thread(contactsActor);
 		actorThread.start();
-		contactActorThread.start();
 		testActor.retrieveContacts(testContactIdentifier1, testContactIdentifier2);
 		actorThread.join();
-		contactActorThread.join();
 		Contact testContactChanged1 = receivedContacts.get(0);
 		Contact testContactChanged2 = receivedContacts.get(1);
 
@@ -213,7 +187,6 @@ public class ContactsActorTest {
 		testContactChanged2.addDrop(testDropUrl);
 		testActor.writeContacts(testContactChanged1, testContactChanged2);
 		actorThread.join();
-		contactActorThread.join();
 
 		// Get changed Contact from Contacts list
 		Contact writtenContact1 = contacts.getByKeyIdentifier(testContactIdentifier1);

--- a/src/test/java/de/qabel/core/config/ContactsActorTest.java
+++ b/src/test/java/de/qabel/core/config/ContactsActorTest.java
@@ -64,9 +64,9 @@ public class ContactsActorTest {
 		Contact testContactRetrieveAll2 = contactFactory.create();
 		Contact testContactRetrieveAll3 = contactFactory.create();
 
-		contacts.add(testContactRetrieveAll1);
-		contacts.add(testContactRetrieveAll2);
-		contacts.add(testContactRetrieveAll3);
+		contacts.put(testContactRetrieveAll1);
+		contacts.put(testContactRetrieveAll2);
+		contacts.put(testContactRetrieveAll3);
 
 		testActor.writeContacts(testContactRetrieveAll1, testContactRetrieveAll2, testContactRetrieveAll3);
 		testActor.retrieveContacts();
@@ -78,7 +78,7 @@ public class ContactsActorTest {
 	public void removeSingleContactTest() throws InterruptedException {
 		Contact testContactRemoveSingle = contactFactory.create();
 		Contacts contacts = new Contacts();
-		contacts.add(testContactRemoveSingle);
+		contacts.put(testContactRemoveSingle);
 
 		testActor.writeContacts(testContactRemoveSingle);
 		testActor.removeContacts(testContactRemoveSingle.getKeyIdentifier());
@@ -92,8 +92,8 @@ public class ContactsActorTest {
 		Contacts contacts = new Contacts();
 		Contact testContactRemoveMultiple1 = contactFactory.create();
 		Contact testContactRemoveMultiple2 = contactFactory.create();
-		contacts.add(testContactRemoveMultiple1);
-		contacts.add(testContactRemoveMultiple2);
+		contacts.put(testContactRemoveMultiple1);
+		contacts.put(testContactRemoveMultiple2);
 
 		testActor.writeContacts(testContactRemoveMultiple1, testContactRemoveMultiple2);
 		testActor.removeContacts(testContactRemoveMultiple1.getKeyIdentifier(),
@@ -110,7 +110,7 @@ public class ContactsActorTest {
 		Contacts contacts = new Contacts();
 		Contact testContactOriginal = contactFactory.create();
 		String testContactIdentifier = testContactOriginal.getKeyIdentifier();
-		contacts.add(testContactOriginal);
+		contacts.put(testContactOriginal);
 
 		testActor.writeContacts(testContactOriginal);
 
@@ -143,8 +143,8 @@ public class ContactsActorTest {
 		Contact testContactOriginal2 = contactFactory.create();
 		String testContactIdentifier1 = testContactOriginal1.getKeyIdentifier();
 		String testContactIdentifier2 = testContactOriginal2.getKeyIdentifier();
-		contacts.add(testContactOriginal1);
-		contacts.add(testContactOriginal2);
+		contacts.put(testContactOriginal1);
+		contacts.put(testContactOriginal2);
 
 		testActor.writeContacts(testContactOriginal1, testContactOriginal2);
 

--- a/src/test/java/de/qabel/core/config/ContactsEquivalentTestFactory.java
+++ b/src/test/java/de/qabel/core/config/ContactsEquivalentTestFactory.java
@@ -16,8 +16,8 @@ class ContactsEquivalentTestFactory implements EquivalentFactory<Contacts>{
 	public Contacts create() {
 		Contacts contacts = new Contacts();
 
-		contacts.add(a);
-		contacts.add(b);
+		contacts.put(a);
+		contacts.put(b);
 
 		return contacts;
 	}

--- a/src/test/java/de/qabel/core/config/ContactsTestFactory.java
+++ b/src/test/java/de/qabel/core/config/ContactsTestFactory.java
@@ -17,8 +17,8 @@ class ContactsTestFactory implements Factory<Contacts>{
 	public Contacts create() {
 		Contacts contacts = new Contacts();
 
-		contacts.add(contactFactory.create());
-		contacts.add(contactFactory.create());
+		contacts.put(contactFactory.create());
+		contacts.put(contactFactory.create());
 
 		return contacts;
 	}

--- a/src/test/java/de/qabel/core/config/DropServersEquivalentTestFactory.java
+++ b/src/test/java/de/qabel/core/config/DropServersEquivalentTestFactory.java
@@ -21,8 +21,8 @@ class DropServersEquivalentTestFactory implements EquivalentFactory<DropServers>
 	public DropServers create() {
 		DropServers dropServers = new DropServers();
 
-		dropServers.add(a);
-		dropServers.add(b);
+		dropServers.put(a);
+		dropServers.put(b);
 
 		return dropServers;
 	}

--- a/src/test/java/de/qabel/core/config/DropServersTestFactory.java
+++ b/src/test/java/de/qabel/core/config/DropServersTestFactory.java
@@ -18,8 +18,8 @@ class DropServersTestFactory implements Factory<DropServers>{
 	public DropServers create() {
 		DropServers dropServers = new DropServers();
 		
-		dropServers.add(dropServerFactory.create());
-		dropServers.add(dropServerFactory.create());
+		dropServers.put(dropServerFactory.create());
+		dropServers.put(dropServerFactory.create());
 		
 		return dropServers;
 	}

--- a/src/test/java/de/qabel/core/config/IdentitiesEquivalentTestFactory.java
+++ b/src/test/java/de/qabel/core/config/IdentitiesEquivalentTestFactory.java
@@ -21,8 +21,8 @@ class IdentitiesEquivalentTestFactory implements EquivalentFactory<Identities>{
 	public Identities create() {
 		Identities identities = new Identities();
 
-		identities.add(a);
-		identities.add(b);
+		identities.put(a);
+		identities.put(b);
 
 		return identities;
 	}

--- a/src/test/java/de/qabel/core/config/IdentitiesTestFactory.java
+++ b/src/test/java/de/qabel/core/config/IdentitiesTestFactory.java
@@ -14,8 +14,8 @@ class IdentitiesTestFactory implements Factory<Identities>{
 		
 		IdentityTestFactory identityFactory = new IdentityTestFactory();
 		
-		ids.add(identityFactory.create());
-		ids.add(identityFactory.create());
+		ids.put(identityFactory.create());
+		ids.put(identityFactory.create());
 		
 		return ids;
 	}

--- a/src/test/java/de/qabel/core/config/PersistenceTest.java
+++ b/src/test/java/de/qabel/core/config/PersistenceTest.java
@@ -38,7 +38,7 @@ public class PersistenceTest {
 		Assert.assertTrue(persistence.persistEntity(pto));
 		Assert.assertTrue(persistence.persistEntity(pto2));
 
-		List<Object> objects = persistence.getEntities(PersistenceTestObject.class);
+		List<Persistable> objects = persistence.getEntities(PersistenceTestObject.class);
 		Assert.assertEquals(2, objects.size());
 		Assert.assertTrue(objects.contains(pto));
 		Assert.assertTrue(objects.contains(pto2));
@@ -46,7 +46,7 @@ public class PersistenceTest {
 
 	@Test
 	public void getEntitiesEmptyTest() {
-		List<Object> objects = persistence.getEntities(PersistenceTestObject.class);
+		List<Persistable> objects = persistence.getEntities(PersistenceTestObject.class);
 		Assert.assertEquals(0, objects.size());
 	}
 

--- a/src/test/java/de/qabel/core/config/StorageServersEquivalentTestFactory.java
+++ b/src/test/java/de/qabel/core/config/StorageServersEquivalentTestFactory.java
@@ -21,8 +21,8 @@ class StorageServersEquivalentTestFactory implements EquivalentFactory<StorageSe
 	public StorageServers create() {
 		StorageServers storageServers = new StorageServers();
 
-		storageServers.add(a);
-		storageServers.add(b);
+		storageServers.put(a);
+		storageServers.put(b);
 
 		return storageServers;
 	}

--- a/src/test/java/de/qabel/core/config/StorageServersTestFactory.java
+++ b/src/test/java/de/qabel/core/config/StorageServersTestFactory.java
@@ -17,8 +17,8 @@ public class StorageServersTestFactory implements Factory<StorageServers>{
 	@Override
 	public StorageServers create() {
 		StorageServers servers = new StorageServers();
-		servers.add(serverFactory.create());
-		servers.add(serverFactory.create());
+		servers.put(serverFactory.create());
+		servers.put(serverFactory.create());
 		return servers;
 	}
 }

--- a/src/test/java/de/qabel/core/config/StorageVolumesEquivalentTestFactory.java
+++ b/src/test/java/de/qabel/core/config/StorageVolumesEquivalentTestFactory.java
@@ -21,8 +21,8 @@ public class StorageVolumesEquivalentTestFactory implements EquivalentFactory<St
 	public StorageVolumes create() {
 		StorageVolumes storageVolumes = new StorageVolumes();
 
-		storageVolumes.add(a);
-		storageVolumes.add(b);
+		storageVolumes.put(a);
+		storageVolumes.put(b);
 
 		return storageVolumes;
 	}

--- a/src/test/java/de/qabel/core/config/StorageVolumesTestFactory.java
+++ b/src/test/java/de/qabel/core/config/StorageVolumesTestFactory.java
@@ -17,8 +17,8 @@ class StorageVolumesTestFactory implements Factory<StorageVolumes>{
 	public StorageVolumes create() {
 		StorageVolumes storageVolumes = new StorageVolumes();
 
-		storageVolumes.add(volumeFactory.create());
-		storageVolumes.add(volumeFactory.create());
+		storageVolumes.put(volumeFactory.create());
+		storageVolumes.put(volumeFactory.create());
 		
 		return storageVolumes;
 	}

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -51,19 +51,19 @@ public class DropActorTest {
     	senderContact = new Contact(this.recipient, this.sender.getDropUrls(), sender.getEcPublicKey());
 
     	identities = new Identities();
-    	identities.add(this.sender);
-    	identities.add(this.recipient);
+    	identities.put(this.sender);
+    	identities.put(this.recipient);
 
     	contacts = new Contacts();
-    	contacts.add(senderContact);
-    	contacts.add(recipientContact);
+    	contacts.put(senderContact);
+    	contacts.put(recipientContact);
 
         DropServers servers = new DropServers();
 
         DropServer iDropServer = new DropServer(new URL(iUrl), null, true);
         DropServer cDropServer = new DropServer(new URL(cUrl), null, true);
-        servers.add(iDropServer);
-        servers.add(cDropServer);
+        servers.put(iDropServer);
+        servers.put(cDropServer);
 
         controller = new DropCommunicatorUtil<TestMessage>(emitter);
         controller.start(contacts, identities, servers);

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -22,6 +22,7 @@ public class DropActorTest {
     private Identities identities;
     private Contacts contacts;
     private EventEmitter emitter;
+	private Thread contactsActorThread;
 
     static class TestMessage extends ModelObject {
         public String content;
@@ -33,7 +34,9 @@ public class DropActorTest {
     
     @Before
     public void setup() throws MalformedURLException, QblDropInvalidURL, InvalidKeyException, InterruptedException {
-        emitter = new EventEmitter();
+        contactsActorThread = new Thread(ContactsActor.getDefault());
+        contactsActorThread.start();
+        emitter = EventEmitter.getDefault();
     	sender = new Identity("Alice", null, new QblECKeyPair());
     	sender.addDrop(new DropURL(iUrl));
     	recipient = new Identity("Bob", null, new QblECKeyPair());
@@ -64,6 +67,7 @@ public class DropActorTest {
     @After
     public void tearDown() throws InterruptedException {
         controller.stop();
+		ContactsActor.getDefault().stop();
     }
 
     @Test

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -23,6 +23,8 @@ public class DropActorTest {
     private Contacts contacts;
     private EventEmitter emitter;
 	private Thread contactsActorThread;
+    private Thread configActorThread;
+	private final static char[] encryptionPassword = "qabel".toCharArray();
 
     static class TestMessage extends ModelObject {
         public String content;
@@ -34,8 +36,11 @@ public class DropActorTest {
     
     @Before
     public void setup() throws MalformedURLException, QblDropInvalidURL, InvalidKeyException, InterruptedException {
+		Persistence.setPassword(encryptionPassword);
         contactsActorThread = new Thread(ContactsActor.getDefault());
         contactsActorThread.start();
+		configActorThread = new Thread(ConfigActor.getDefault());
+		configActorThread.start();
         emitter = EventEmitter.getDefault();
     	sender = new Identity("Alice", null, new QblECKeyPair());
     	sender.addDrop(new DropURL(iUrl));
@@ -68,6 +73,7 @@ public class DropActorTest {
     public void tearDown() throws InterruptedException {
         controller.stop();
 		ContactsActor.getDefault().stop();
+		ConfigActor.getDefault().stop();
     }
 
     @Test

--- a/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
+++ b/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
@@ -4,9 +4,7 @@ import de.qabel.ackack.MessageInfo;
 import de.qabel.ackack.event.EventActor;
 import de.qabel.ackack.event.EventEmitter;
 import de.qabel.ackack.event.EventListener;
-import de.qabel.core.config.Contacts;
-import de.qabel.core.config.DropServers;
-import de.qabel.core.config.Identities;
+import de.qabel.core.config.*;
 import de.qabel.core.module.Module;
 
 import java.util.concurrent.LinkedBlockingQueue;
@@ -15,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 public class DropCommunicatorUtil <T extends ModelObject> {
 	private final EventEmitter emitter;
 	LinkedBlockingQueue<DropMessage<T>> inputqueue = new LinkedBlockingQueue<>();
+	private ContactsActor contactsActor;
 	private EventActor actor;
 	private DropActor dropActor;
 	private Thread actorThread;
@@ -22,6 +21,7 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 	Class<?> cls;
 	public DropCommunicatorUtil(EventEmitter emitter) {
 		this.emitter = emitter;
+		this.contactsActor = ContactsActor.getDefault();
 	}
 
 	public void setCls(Class<?> cls) {
@@ -43,7 +43,7 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 			}
 		});
 		this.dropActor = new DropActor(emitter);
-		this.dropActor.setContacts(contacts);
+		this.contactsActor.writeContacts(contacts.getContacts().toArray(new Contact[0]));
 		this.dropActor.setDropServers(dropServers);
 		this.dropActor.setIdentities(identities);
 		this.actorThread = new Thread(actor, "actor");
@@ -58,6 +58,7 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 	public void stop() throws InterruptedException {
 		this.actor.stop();
 		this.dropActor.stop();
+		this.dropActor.unregister();
 		this.actorThread.join();
 		this.dropActorThread.join();
 	}

--- a/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
+++ b/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
@@ -72,6 +72,6 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 	}
 
 	public DropMessage<T> retrieve() throws InterruptedException {
-		return inputqueue.poll(2000, TimeUnit.MILLISECONDS);
+		return inputqueue.take();
 	}
 }

--- a/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
+++ b/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
@@ -5,7 +5,6 @@ import de.qabel.ackack.event.EventActor;
 import de.qabel.ackack.event.EventEmitter;
 import de.qabel.ackack.event.EventListener;
 import de.qabel.core.config.*;
-import de.qabel.core.module.Module;
 
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -14,14 +13,18 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 	private final EventEmitter emitter;
 	LinkedBlockingQueue<DropMessage<T>> inputqueue = new LinkedBlockingQueue<>();
 	private ContactsActor contactsActor;
+	private ConfigActor configActor;
 	private EventActor actor;
 	private DropActor dropActor;
 	private Thread actorThread;
 	private Thread dropActorThread;
+	private Identities identities;
+	private DropServers dropServers;
 	Class<?> cls;
 	public DropCommunicatorUtil(EventEmitter emitter) {
 		this.emitter = emitter;
 		this.contactsActor = ContactsActor.getDefault();
+		this.configActor = ConfigActor.getDefault();
 	}
 
 	public void setCls(Class<?> cls) {
@@ -29,6 +32,8 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 	}
 
 	public void start(Contacts contacts, Identities identities, DropServers dropServers) throws InterruptedException {
+		this.identities = identities;
+		this.dropServers = dropServers;
 		this.actor = new EventActor(emitter);
 		this.actor.on(DropActor.EVENT_DROP_MESSAGE_RECEIVED, new EventListener() {
 			@Override
@@ -42,10 +47,11 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 				}
 			}
 		});
+
 		this.dropActor = new DropActor(emitter);
 		this.contactsActor.writeContacts(contacts.getContacts().toArray(new Contact[0]));
-		this.dropActor.setDropServers(dropServers);
-		this.dropActor.setIdentities(identities);
+		this.configActor.writeIdentities(identities.getIdentities().toArray(new Identity[0]));
+		this.configActor.writeDropServers(dropServers.getDropServers().toArray(new DropServer[0]));
 		this.actorThread = new Thread(actor, "actor");
 		this.dropActorThread = new Thread(dropActor, "dropActor");
 		this.dropActor.setInterval(500);
@@ -59,6 +65,8 @@ public class DropCommunicatorUtil <T extends ModelObject> {
 		this.actor.stop();
 		this.dropActor.stop();
 		this.dropActor.unregister();
+		this.configActor.removeIdentities(identities.getIdentities().toArray(new Identity[0]));
+		this.configActor.removeDropServers(dropServers.getDropServers().toArray(new DropServer[0]));
 		this.actorThread.join();
 		this.dropActorThread.join();
 	}

--- a/src/test/java/de/qabel/core/drop/DropMessageGsonTest.java
+++ b/src/test/java/de/qabel/core/drop/DropMessageGsonTest.java
@@ -61,7 +61,7 @@ public class DropMessageGsonTest {
         m.content = "baz";
         Identity sender = new Identity("Bernd", new ArrayList<DropURL>(), new QblECKeyPair());
         Identities identities = new Identities();
-        identities.add(sender);
+        identities.put(sender);
         DropMessage<TestMessage> a = new DropMessage<TestMessage>(sender, m);
 
         GsonBuilder builder = new GsonBuilder();


### PR DESCRIPTION
Refactored DropActor to get resources via events. ~~The ContactActorTest has some concurrency issues, because modifying contacts is done in a different thread, which cannot be joined anymore. This might be avoided with a simple sleep, but maybe there is a cleaner solution.~~ EDIT: ContactActorTest now listens to contact added and removed events to wait until events has been processed.

- [X] Get Contacts via event
- [x] Get Identities via event
- [x] Get DropServers via event
- [x] Eliminated concurrency problems with ContactActorTest

~~This is related to #327, but does not closes it in the current state.~~
~~The unregister method from https://github.com/Qabel/ackack/pull/7 is required for this PR.~~ -> merged

~~Synchronization may get further optimized.~~ -> done

~~Requires #334~~ -> merged 
- [x] Fix timeout with large persistence file
- [x] Default LocalSettings -> #343 
- [X] Define when to emit config changes -> #344 
- [x] Check synchronization in Config and ContactActor

Fixes #336 
Closes #327 