### PR TITLE
Makes the function public

### DIFF
--- a/src/main/java/de/qabel/core/config/ContactsActor.java
+++ b/src/main/java/de/qabel/core/config/ContactsActor.java
@@ -17,7 +17,7 @@ public class ContactsActor extends Actor {
 	private Contacts contacts;
 	private Persistence persistence;
 
-	static ContactsActor getDefault() {
+	public static ContactsActor getDefault() {
 		if (defaultContactsActor == null) {
 			defaultContactsActor = new ContactsActor();
 		}


### PR DESCRIPTION
This will fix one of the errors, which showed up in Qabel/qabel#9.
This PR makes the getDefault in ContactsActor public, because otherwise the function is only package-private. It is used by the desktop-module, which fails to build.