### PR TITLE
Deserialization validator example

### DIFF
--- a/src/main/java/de/qabel/core/config/Account.java
+++ b/src/main/java/de/qabel/core/config/Account.java
@@ -9,6 +9,7 @@ public class Account extends SyncSettingItem {
 	 * Provider of the account
 	 * Field name in serialized json: "provider"
 	 */
+	@RequiredInJson
 	private String provider;
 	/**
 	 * User of the account
@@ -19,6 +20,7 @@ public class Account extends SyncSettingItem {
 	 * Authentication of the account
 	 * Field name in serialized json: "auth"
 	 */
+	@RequiredInJson
 	private String auth;
 	
 	/**

--- a/src/main/java/de/qabel/core/config/DeserializedValidator.java
+++ b/src/main/java/de/qabel/core/config/DeserializedValidator.java
@@ -1,0 +1,26 @@
+package de.qabel.core.config;
+
+import java.lang.reflect.Field;
+
+import com.google.gson.JsonParseException;
+
+class DeserializedValidator {
+	static void validate(Object obj) throws JsonParseException{
+		Field[] fields = obj.getClass().getDeclaredFields();
+		for(Field field : fields) {
+			if (!field.isAnnotationPresent(RequiredInJson.class))
+				continue;
+			
+			field.setAccessible(true);
+			try {
+				if (field.get(obj) == null) {
+					throw new JsonParseException("In JSON object \"" + obj.getClass()
+							+ "\" the field \"" + field.getName() + "\" is missing.");
+				}
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/src/main/java/de/qabel/core/config/RequiredInJson.java
+++ b/src/main/java/de/qabel/core/config/RequiredInJson.java
@@ -1,0 +1,6 @@
+package de.qabel.core.config;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public @Retention(RetentionPolicy.RUNTIME) @interface RequiredInJson { }

--- a/src/test/java/de/qabel/core/config/DeserializationValidatorTest.java
+++ b/src/test/java/de/qabel/core/config/DeserializationValidatorTest.java
@@ -1,0 +1,29 @@
+package de.qabel.core.config;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+
+public class DeserializationValidatorTest {
+	
+	@Test(expected=JsonParseException.class)
+	public void requiredItemMissingTest() throws IOException, JsonParseException, IllegalArgumentException, IllegalAccessException {
+		// Test string with missing item "auth":
+		String testString = "{\"provider\":\"provider\",\"user\":\"user\"}";
+		Gson gson = new Gson();
+		Account testAccount = gson.fromJson(testString, Account.class);
+		DeserializedValidator.validate(testAccount);
+	}
+
+	@Test
+	public void notRequiredItemMissingTest() {
+		// Test string with missing item "user":
+		String testString = "{\"provider\":\"provider\",\"auth\":\"auth\"}";
+		Gson gson = new Gson();
+		Account testAccount = gson.fromJson(testString, Account.class);
+		DeserializedValidator.validate(testAccount);
+	}
+}


### PR DESCRIPTION
Refers to #248.

GSON does not provide a proper functionality to detect missing items in a JSON input without using a custom TypeAdapter for each class. This PR is a proposal how that issue could be solved.
Therefore please give feedback.

EDIT: Don't merge this, it is just an example.