### PR TITLE
Adapt EntityMap to fit the conventions of the Map interface

### DIFF
--- a/src/main/java/de/qabel/core/config/EntityMap.java
+++ b/src/main/java/de/qabel/core/config/EntityMap.java
@@ -22,19 +22,34 @@ abstract class EntityMap<T extends Entity> implements Serializable {
 		return Collections.unmodifiableSet(new HashSet<>(entities.values()));
 	}
 
-	public synchronized boolean put(T entity) {
-		if (this.entities.put(entity.getKeyIdentifier(), entity) == null) {
-			return false;
-		}
-		return true;
+	/**
+	 * Inserts new Entity into the map associated to its key identifier.
+	 * 
+	 * @param entity Entity to insert
+	 * @return old Entity associated to the same key identifier or null if no such old Entity was present.
+	 */
+	public synchronized T put(T entity) {
+		return this.entities.put(entity.getKeyIdentifier(), entity);
 	}
 
-	public synchronized boolean remove(T entity) {
-		return (entity != null && this.entities.remove(entity.getKeyIdentifier()) != null);
+	/**
+	 * Removes given Entity from the map.
+	 * 
+	 * @param entity Entity to remove
+	 * @return old Entity associated to the key identifier of the given Entity, or null if there was no such Entity
+	 */
+	public synchronized T remove(T entity) {
+		return this.remove(entity.getKeyIdentifier());
 	}
 
-	public synchronized boolean remove(String keyIdentifier) {
-		return (keyIdentifier != null && this.entities.remove(keyIdentifier) != null);
+	/**
+	 * Removes Entity with the given key identifier from the map.
+	 * 
+	 * @param keyIdentifier key identifier of the Entity that is to be removed
+	 * @return old Entity associated to the given key identifier, or null if there was no such Entity
+	 */
+	public synchronized T remove(String keyIdentifier) {
+		return this.entities.remove(keyIdentifier);
 	}
 
 	/**

--- a/src/main/java/de/qabel/core/config/EntityMap.java
+++ b/src/main/java/de/qabel/core/config/EntityMap.java
@@ -9,7 +9,7 @@ import java.util.*;
  * 
  * @see Entity
  */
-abstract public class EntityMap<T extends Entity> implements Serializable {
+abstract class EntityMap<T extends Entity> implements Serializable {
 	private static final long serialVersionUID = -8004819460313825206L;
 	private final Map<String, T> entities = Collections.synchronizedMap(new HashMap<String, T>());
 


### PR DESCRIPTION
This adapts the put and remove functions to fit to the signature of Map interface of the very same name. The old functions were misleading and counter-intuitive (put returned false if already was a Entity associated to the same key identifier but replaced it anyway).

The new behaviour is how developers expect a put function to work from the Map interface.

Furthermore, I reduced to scope of the class to package private because a public scope is unnecessary for this abstract helper class.

The need for a clarification of EntityMap API has originally been expressed in https://github.com/Qabel/qabel-core/pull/305#discussion_r29244060
Closes #287 