### PR TITLE
DropActor uses now the dropUrls of the identities instead of DropServerUrls

### DIFF
--- a/src/main/java/de/qabel/core/drop/DropActor.java
+++ b/src/main/java/de/qabel/core/drop/DropActor.java
@@ -197,12 +197,14 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 	 * retrieves new DropMessages from server and emits EVENT_DROP_MESSAGE_RECEIVED event.
 	 */
 	private void retrieve() {
-		for (DropServer server : mDropServers.getDropServers()) {
-			Collection<DropMessage<?>> results = this.retrieve(server.getUri());
-			MessageInfo mi = new MessageInfo();
-			mi.setType(PRIVATE_TYPE_MESSAGE_INPUT);
-			for (DropMessage<? extends ModelObject> dm : results) {
-				emitter.emit(EVENT_DROP_MESSAGE_RECEIVED_PREFIX + dm.getData().getClass().getCanonicalName(), dm);
+		for(Identity identity : mIdentities.getIdentities()) {
+			for(DropURL dropUrl: identity.getDropUrls()) {
+				Collection<DropMessage<?>> results = this.retrieve(dropUrl.getUri());
+				MessageInfo mi = new MessageInfo();
+				mi.setType(PRIVATE_TYPE_MESSAGE_INPUT);
+				for (DropMessage<? extends ModelObject> dm : results) {
+					emitter.emit(EVENT_DROP_MESSAGE_RECEIVED_PREFIX + dm.getData().getClass().getCanonicalName(), dm);
+				}
 			}
 		}
 	}

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -30,7 +30,6 @@ public class MultiPartCryptoTest {
 	private EventEmitter emitter;
     private Contacts contacts;
     private Identities identities;
-    private DropServers servers;
 	private ResourceActor resourceActor;
 	private Thread resourceActorThread;
 
@@ -73,8 +72,7 @@ public class MultiPartCryptoTest {
         emitter = EventEmitter.getDefault();
 
         loadContactsAndIdentities();
-        loadDropServers();
-		communicatorUtil = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities, servers);
+		communicatorUtil = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities);
     }
 
     @After
@@ -146,20 +144,6 @@ public class MultiPartCryptoTest {
         identities = new Identities();
 		identities.put(alice);
 		identities.put(bob);
-    }
-
-    private void loadDropServers() throws URISyntaxException {
-        servers = new DropServers();
-
-        DropServer alicesServer = new DropServer();
-        alicesServer.setUri(new URI("http://localhost:6000/12345678901234567890123456789012345678alice"));
-
-        DropServer bobsServer = new DropServer();
-        bobsServer.setUri(new URI("http://localhost:6000/1234567890123456789012345678901234567890bob"));
-
-        servers.put(alicesServer);
-        servers.put(bobsServer);
-
     }
 
     private void sendMessage() throws QblDropPayloadSizeException {

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -15,6 +15,7 @@ import java.security.InvalidKeyException;
 import java.util.HashSet;
 
 public class DropActorTest {
+    private static final String dropServer = "http://localhost:6000/";
     private static final String iUrl = "http://localhost:6000/123456789012345678901234567890123456789012c";
     private static String cUrl = "http://localhost:6000/123456789012345678901234567890123456789012d";
 	private static final String DB_NAME = "DropActorTest.sqlite";
@@ -60,11 +61,7 @@ public class DropActorTest {
     	contacts.put(recipientContact);
 
         DropServers servers = new DropServers();
-
-        DropServer iDropServer = new DropServer(new URI(iUrl), null, true);
-        DropServer cDropServer = new DropServer(new URI(cUrl), null, true);
-        servers.put(iDropServer);
-        servers.put(cDropServer);
+        servers.put(new DropServer(new URI(dropServer), null, true));
 
         controller = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities, servers);
         controller.registerModelObject(TestMessage.class);

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -15,7 +15,6 @@ import java.security.InvalidKeyException;
 import java.util.HashSet;
 
 public class DropActorTest {
-    private static final String dropServer = "http://localhost:6000/";
     private static final String iUrl = "http://localhost:6000/123456789012345678901234567890123456789012c";
     private static String cUrl = "http://localhost:6000/123456789012345678901234567890123456789012d";
 	private static final String DB_NAME = "DropActorTest.sqlite";
@@ -60,10 +59,7 @@ public class DropActorTest {
     	contacts.put(senderContact);
     	contacts.put(recipientContact);
 
-        DropServers servers = new DropServers();
-        servers.put(new DropServer(new URI(dropServer), null, true));
-
-        controller = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities, servers);
+        controller = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities);
         controller.registerModelObject(TestMessage.class);
     }
 

--- a/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
+++ b/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
@@ -14,13 +14,12 @@ public class DropCommunicatorUtil extends Module {
 	private DropActor dropActor;
 	private Thread dropActorThread;
 	private Identities identities;
-	private DropServers dropServers;
 
 	public DropCommunicatorUtil(ModuleManager moduleManager) {
 		super(moduleManager);
 	}
 
-	static public DropCommunicatorUtil newInstance(ResourceActor resourceActor, EventEmitter emitter, Contacts contacts, Identities identities, DropServers dropServers) throws IllegalAccessException, InstantiationException {
+	static public DropCommunicatorUtil newInstance(ResourceActor resourceActor, EventEmitter emitter, Contacts contacts, Identities identities) throws IllegalAccessException, InstantiationException {
 		DropActor dropActor = new DropActor(resourceActor, emitter);
 
 		Thread dropActorThread = new Thread(dropActor, "dropActor");
@@ -32,10 +31,8 @@ public class DropCommunicatorUtil extends Module {
 			util.resourceActor = resourceActor;
 			util.resourceActor.writeContacts(contacts.getContacts().toArray(new Contact[0]));
 			util.resourceActor.writeIdentities(identities.getIdentities().toArray(new Identity[0]));
-			util.resourceActor.writeDropServers(dropServers.getDropServers().toArray(new DropServer[0]));
 
 			util.identities = identities;
-			util.dropServers = dropServers;
 			util.dropActor = dropActor;
 			util.dropActorThread = dropActorThread;
 			return util;
@@ -58,7 +55,6 @@ public class DropCommunicatorUtil extends Module {
 		this.dropActor.stop();
 		this.dropActor.unregister();
 		this.resourceActor.removeIdentities(identities.getIdentities().toArray(new Identity[0]));
-		this.resourceActor.removeDropServers(dropServers.getDropServers().toArray(new DropServer[0]));
 		try {
 			this.dropActorThread.join();
 		} catch (InterruptedException e) {


### PR DESCRIPTION
The DropserverUrls should not contain the dropIDs, so we have to
check the dropUrls of the identities.

Closes. #182 