### PR TITLE
Removed unnecessary generic from ResourceActor constructor

### DIFF
--- a/src/main/java/de/qabel/core/config/ResourceActor.java
+++ b/src/main/java/de/qabel/core/config/ResourceActor.java
@@ -55,7 +55,7 @@ public class ResourceActor extends Actor {
 
 	private final static Logger logger = LogManager.getLogger(ResourceActor.class.getName());
 
-	public ResourceActor(Persistence<String> persistence, EventEmitter eventEmitter) {
+	public ResourceActor(Persistence persistence, EventEmitter eventEmitter) {
 		this.persistence = persistence;
 		this.settings = new Settings();
 		this.contacts = new Contacts();


### PR DESCRIPTION
Using a  parameterized type here was just a mistake.