### PR TITLE
Moved static ClassLoader out of ModuleManager

### DIFF
--- a/src/main/java/de/qabel/core/config/QblClassLoader.java
+++ b/src/main/java/de/qabel/core/config/QblClassLoader.java
@@ -1,0 +1,16 @@
+package de.qabel.core.config;
+
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class QblClassLoader extends URLClassLoader {
+	public QblClassLoader(ClassLoader classLoader) {
+		super(new URL[0], classLoader);
+	}
+
+	@Override
+	public void addURL(URL url) {
+		super.addURL(url);
+	}
+}

--- a/src/main/java/de/qabel/core/crypto/AbstractBinaryDropMessage.java
+++ b/src/main/java/de/qabel/core/crypto/AbstractBinaryDropMessage.java
@@ -3,6 +3,7 @@ package de.qabel.core.crypto;
 import java.util.Arrays;
 
 import de.qabel.core.config.Identity;
+import de.qabel.core.config.QblClassLoader;
 import de.qabel.core.exceptions.QblSpoofedSenderException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -74,9 +75,9 @@ public abstract class AbstractBinaryDropMessage {
 	 * @return deserialized Dropmessage or null if deserialization error
 	 *         occurred.
 	 */
-	private static DropMessage<?> deserialize(String plainJson) {
+	private static DropMessage<?> deserialize(String plainJson, QblClassLoader classLoader) {
 		Gson gson = new GsonBuilder().registerTypeAdapter(DropMessage.class,
-				new DropDeserializer()).create();
+				new DropDeserializer(classLoader)).create();
 		try {
 			return gson.fromJson(plainJson, DropMessage.class);
 		} catch (JsonSyntaxException e) {
@@ -116,14 +117,14 @@ public abstract class AbstractBinaryDropMessage {
 	 * @return Disassembled drop message or null if either the sender assumption
 	 *         was wrong or the message verification failed.
 	 */
-	public DropMessage<?> disassembleMessage(Identity identity) throws QblSpoofedSenderException {
+	public DropMessage<?> disassembleMessage(Identity identity, QblClassLoader classLoader) throws QblSpoofedSenderException {
 		DecryptedPlaintext decryptedPlaintext = disassembleRawMessage(identity);
 		if (decryptedPlaintext == null){
 			return null;
 		}
 
 		DropMessage<?> dropMessage = deserialize(new String(
-				discardPaddingBytes(decryptedPlaintext.getPlaintext())));
+				discardPaddingBytes(decryptedPlaintext.getPlaintext())), classLoader);
 		if (dropMessage == null) {
 			logger.debug("Message could not be deserialized. Msg: "
 					+ new String(decryptedPlaintext.getPlaintext()));

--- a/src/main/java/de/qabel/core/drop/DropActor.java
+++ b/src/main/java/de/qabel/core/drop/DropActor.java
@@ -37,6 +37,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 	private DropServers mDropServers;
 	private Identities mIdentities;
 	private Contacts mContacts;
+	private QblClassLoader classLoader;
 	GsonBuilder gb;
 	Gson gson;
 	ReceiverThread receiver;
@@ -52,15 +53,16 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 		return interval;
 	}
 
-	public DropActor(ResourceActor resourceActor, EventEmitter emitter) {
+	public DropActor(ResourceActor resourceActor, EventEmitter emitter, QblClassLoader classLoader) {
 		super(emitter);
 		this.emitter = emitter;
 		this.mContacts = new Contacts();
 		this.mIdentities = new Identities();
 		this.mDropServers = new DropServers();
+		this.classLoader = classLoader;
 		gb = new GsonBuilder();
 		gb.registerTypeAdapter(DropMessage.class, new DropSerializer());
-		gb.registerTypeAdapter(DropMessage.class, new DropDeserializer());
+		gb.registerTypeAdapter(DropMessage.class, new DropDeserializer(classLoader));
 		gson = gb.create();
 		on(EVENT_ACTION_DROP_MESSAGE_SEND, this);
 		on(EventNameConstants.EVENT_CONTACT_ADDED, this);
@@ -319,7 +321,7 @@ public class DropActor extends EventActor implements de.qabel.ackack.event.Event
 			for (Identity identity : mIdentities.getIdentities()) {
 				DropMessage<?> dropMessage = null;
 				try {
-					dropMessage = binMessage.disassembleMessage(identity);
+					dropMessage = binMessage.disassembleMessage(identity, classLoader);
 				} catch (QblSpoofedSenderException e) {
 					//TODO: Notify the user about the spoofed message
 					break;

--- a/src/main/java/de/qabel/core/drop/DropDeserializer.java
+++ b/src/main/java/de/qabel/core/drop/DropDeserializer.java
@@ -9,10 +9,18 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
+import de.qabel.core.config.QblClassLoader;
 import de.qabel.core.module.ModuleManager;
 
 
 public class DropDeserializer implements JsonDeserializer<DropMessage<ModelObject>> {
+
+    private final QblClassLoader classLoader;
+
+    public DropDeserializer(QblClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
     @Override
     public DropMessage<ModelObject> deserialize(JsonElement json, Type type,
                                                 JsonDeserializationContext context) throws JsonParseException {
@@ -28,10 +36,8 @@ public class DropDeserializer implements JsonDeserializer<DropMessage<ModelObjec
 
         ModelObject m;
         try {
-            ClassLoader loader = ModuleManager.LOADER;
-
             @SuppressWarnings("unchecked")
-            Class<? extends ModelObject> cls = (Class<? extends ModelObject>) loader
+            Class<? extends ModelObject> cls = (Class<? extends ModelObject>) classLoader
                     .loadClass(model);
             m = new Gson().fromJson(json.getAsJsonObject().get("data").getAsJsonObject(), cls);
         } catch (ClassNotFoundException e1) {

--- a/src/main/java/de/qabel/core/module/ModuleManager.java
+++ b/src/main/java/de/qabel/core/module/ModuleManager.java
@@ -1,12 +1,11 @@
 package de.qabel.core.module;
 
 import de.qabel.ackack.event.EventEmitter;
+import de.qabel.core.config.QblClassLoader;
 import de.qabel.core.config.ResourceActor;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.HashMap;
 
 /**
@@ -14,30 +13,22 @@ import java.util.HashMap;
  * stopping and removing them.
  */
 public class ModuleManager {
-	public final static ClassLoader LOADER = new ClassLoader();
+	private final QblClassLoader classLoader;
 
 	private final EventEmitter eventEmitter;
 	private final ResourceActor resourceActor;
 
 	private HashMap<Module, ModuleThread> modules;
 
-
-	static public class ClassLoader extends URLClassLoader{
-		public ClassLoader() {
-			super(new URL[0]);
-		}
-
-		@Override
-		public void addURL(URL url) {
-			super.addURL(url);
-		}
+	public ModuleManager(EventEmitter emitter, ResourceActor resourceActor) {
+		this(emitter, resourceActor, new QblClassLoader(ClassLoader.getSystemClassLoader()));
 	}
 
-
-	public ModuleManager(EventEmitter emitter, ResourceActor resourceActor) {
+	public ModuleManager(EventEmitter emitter, ResourceActor resourceActor, QblClassLoader classLoader) {
 		eventEmitter = emitter;
 		modules = new HashMap<>();
 		this.resourceActor = resourceActor;
+		this.classLoader = classLoader;
 	}
 
 	EventEmitter getEventEmitter() {
@@ -65,9 +56,8 @@ public class ModuleManager {
 
 	public void startModule(File jar, String className) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
 		try {
-			ClassLoader cld = LOADER;
-			cld.addURL(jar.toURI().toURL());
-			Class cls = Class.forName(className, true, cld);
+			classLoader.addURL(jar.toURI().toURL());
+			Class cls = Class.forName(className, true, classLoader);
 			try {
 				startModule(cls.asSubclass(Module.class));
 			}

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -72,7 +72,7 @@ public class MultiPartCryptoTest {
         emitter = EventEmitter.getDefault();
 
         loadContactsAndIdentities();
-		communicatorUtil = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities);
+		communicatorUtil = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities, new QblClassLoader(ClassLoader.getSystemClassLoader()));
     }
 
     @After

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -59,7 +59,7 @@ public class DropActorTest {
     	contacts.put(senderContact);
     	contacts.put(recipientContact);
 
-        controller = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities);
+        controller = DropCommunicatorUtil.newInstance(resourceActor, emitter, contacts, identities, new QblClassLoader(ClassLoader.getSystemClassLoader()));
         controller.registerModelObject(TestMessage.class);
     }
 

--- a/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
+++ b/src/test/java/de/qabel/core/drop/DropCommunicatorUtil.java
@@ -19,8 +19,8 @@ public class DropCommunicatorUtil extends Module {
 		super(moduleManager);
 	}
 
-	static public DropCommunicatorUtil newInstance(ResourceActor resourceActor, EventEmitter emitter, Contacts contacts, Identities identities) throws IllegalAccessException, InstantiationException {
-		DropActor dropActor = new DropActor(resourceActor, emitter);
+	static public DropCommunicatorUtil newInstance(ResourceActor resourceActor, EventEmitter emitter, Contacts contacts, Identities identities, QblClassLoader classLoader) throws IllegalAccessException, InstantiationException {
+		DropActor dropActor = new DropActor(resourceActor, emitter, classLoader);
 
 		Thread dropActorThread = new Thread(dropActor, "dropActor");
 		dropActor.setInterval(500);

--- a/src/test/java/de/qabel/core/drop/DropMessageGsonTest.java
+++ b/src/test/java/de/qabel/core/drop/DropMessageGsonTest.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonSyntaxException;
 
 import de.qabel.core.config.Identities;
 import de.qabel.core.config.Identity;
+import de.qabel.core.config.QblClassLoader;
 import de.qabel.core.crypto.QblECKeyPair;
 
 import org.junit.Test;
@@ -31,7 +32,7 @@ public class DropMessageGsonTest {
 	GsonBuilder builder = new GsonBuilder();
         builder.registerTypeAdapter(DropMessage.class, new DropTypeAdapter<>());
         builder.registerTypeAdapter(DropMessage.class, new DropSerializer());
-        builder.registerTypeAdapter(DropMessage.class, new DropDeserializer());
+        builder.registerTypeAdapter(DropMessage.class, new DropDeserializer(new QblClassLoader(ClassLoader.getSystemClassLoader())));
 	
 	Gson gson = builder.create();
 	
@@ -47,7 +48,7 @@ public class DropMessageGsonTest {
 	GsonBuilder builder = new GsonBuilder();
         builder.registerTypeAdapter(DropMessage.class, new DropTypeAdapter<>());
         builder.registerTypeAdapter(DropMessage.class, new DropSerializer());
-        builder.registerTypeAdapter(DropMessage.class, new DropDeserializer());
+        builder.registerTypeAdapter(DropMessage.class, new DropDeserializer(new QblClassLoader(ClassLoader.getSystemClassLoader())));
 	
 	Gson gson = builder.create();
 	
@@ -67,7 +68,7 @@ public class DropMessageGsonTest {
         GsonBuilder builder = new GsonBuilder();
         builder.registerTypeAdapter(DropMessage.class, new DropTypeAdapter<TestMessage>());
         builder.registerTypeAdapter(DropMessage.class, new DropSerializer());
-        builder.registerTypeAdapter(DropMessage.class, new DropDeserializer());
+        builder.registerTypeAdapter(DropMessage.class, new DropDeserializer(new QblClassLoader(ClassLoader.getSystemClassLoader())));
 
         Gson gson = builder.create();
 


### PR DESCRIPTION
The DropDeserializer has used the static ClassLoader member of the ModuleManager.
This is a bad and unnecessary coupling of two unrelated classes via an ugly static construct.

Instead the required ClassLoader is instantiated by the creator of the ModuleManager
and the DropActor. Although this requires more code, the ownership and relations are more clear.

Further it is not possible to deserialize DropMessages on Android with this construct: 
```
07-15 11:03:52.041  25861-25893/qabel.de.qabel_android E/AndroidRuntime﹕ FATAL EXCEPTION: Thread-1692
    Process: qabel.de.qabel_android, PID: 25861
    com.google.gson.JsonParseException: Couldn't deserialize 'data' entry
            at de.qabel.core.drop.DropDeserializer.deserialize(DropDeserializer.java:38)
            at de.qabel.core.drop.DropDeserializer.deserialize(DropDeserializer.java:15)
            at com.google.gson.TreeTypeAdapter.read(TreeTypeAdapter.java:58)
            at com.google.gson.Gson.fromJson(Gson.java:810)
            at com.google.gson.Gson.fromJson(Gson.java:775)
            at com.google.gson.Gson.fromJson(Gson.java:724)
            at com.google.gson.Gson.fromJson(Gson.java:696)
            at de.qabel.core.crypto.AbstractBinaryDropMessage.deserialize(AbstractBinaryDropMessage.java:81)
            at de.qabel.core.crypto.AbstractBinaryDropMessage.disassembleMessage(AbstractBinaryDropMessage.java:125)
            at de.qabel.core.drop.DropActor.retrieve(DropActor.java:320)
            at de.qabel.core.drop.DropActor.retrieve(DropActor.java:201)
            at de.qabel.core.drop.DropActor.access$400(DropActor.java:30)
            at de.qabel.core.drop.DropActor$ReceiverThread.run(DropActor.java:393)
     Caused by: java.lang.ClassNotFoundException: de.qabel.qabel_android.HelloWorldObject
            at java.net.URLClassLoader.findClass(URLClassLoader.java:753)
            at java.lang.ClassLoader.loadClass(ClassLoader.java:511)
            at java.lang.ClassLoader.loadClass(ClassLoader.java:469)
            at de.qabel.core.drop.DropDeserializer.deserialize(DropDeserializer.java:34)
            at de.qabel.core.drop.DropDeserializer.deserialize(DropDeserializer.java:15)
            at com.google.gson.TreeTypeAdapter.read(TreeTypeAdapter.java:58)
            at com.google.gson.Gson.fromJson(Gson.java:810)
            at com.google.gson.Gson.fromJson(Gson.java:775)
            at com.google.gson.Gson.fromJson(Gson.java:724)
            at com.google.gson.Gson.fromJson(Gson.java:696)
            at de.qabel.core.crypto.AbstractBinaryDropMessage.deserialize(AbstractBinaryDropMessage.java:81)
            at de.qabel.core.crypto.AbstractBinaryDropMessage.disassembleMessage(AbstractBinaryDropMessage.java:125)
            at de.qabel.core.drop.DropActor.retrieve(DropActor.java:320)
            at de.qabel.core.drop.DropActor.retrieve(DropActor.java:201)
            at de.qabel.core.drop.DropActor.access$400(DropActor.java:30)
            at de.qabel.core.drop.DropActor$ReceiverThread.run(DropActor.java:393)
    Suppressed: java.lang.ClassNotFoundException: Didn't find class "de.qabel.qabel_android.HelloWorldObject" on path: DexPathList[[directory "."],nativeLibraryDirectories=[/vendor/lib, /system/lib]]
            at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:56)
            at java.lang.ClassLoader.loadClass(ClassLoader.java:511)
            at java.lang.ClassLoader.loadClass(ClassLoader.java:504)
            ... 14 more
    Suppressed: java.lang.ClassNotFoundException: de.qabel.qabel_android.HelloWorldObject
            at java.lang.Class.classForName(Native Method)
            at java.lang.BootClassLoader.findClass(ClassLoader.java:781)
            at java.lang.BootClassLoader.loadClass(ClassLoader.java:841)
            at java.lang.ClassLoader.loadClass(ClassLoader.java:504)
            ... 15 more
     Caused by: java.lang.NoClassDefFoundError: Class not found using the boot class loader; no stack available
```