### PR TITLE
Added exception when opening persistence with wrong password

### DIFF
--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -1,6 +1,7 @@
 package de.qabel.core.config;
 
 import de.qabel.core.crypto.CryptoUtils;
+import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -34,7 +35,7 @@ public abstract class Persistence<T> {
 	private SecretKeyFactory secretKeyFactory;
 	CryptoUtils cryptoutils;
 
-	public Persistence(T database, char[] password) {
+	public Persistence(T database, char[] password) throws QblInvalidEncryptionKeyException {
 		this.cryptoutils = new CryptoUtils();
 		try {
 			this.secretKeyFactory = SecretKeyFactory.getInstance(SECRET_KEY_ALGORITHM);
@@ -47,6 +48,9 @@ public abstract class Persistence<T> {
 			throw new RuntimeException("Cannot connect to database!");
 		}
 		this.keyParameter = getMasterKey(deriveKey(password, getSalt(false)));
+		if (this.keyParameter == null) {
+			throw new QblInvalidEncryptionKeyException();
+		}
 	}
 
 	/**

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -1,5 +1,6 @@
 package de.qabel.core.config;
 
+import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.InvalidCipherTextException;
@@ -28,7 +29,7 @@ public class SQLitePersistence extends Persistence<String> {
 	 * Stores entities in a local SQLite database
 	 * @param dbName Database file name.
 	 */
-	public SQLitePersistence(String dbName, char[] password) {
+	public SQLitePersistence(String dbName, char[] password) throws QblInvalidEncryptionKeyException {
 		super(dbName, password);
 	}
 
@@ -78,6 +79,7 @@ public class SQLitePersistence extends Persistence<String> {
 				masterKey = cryptoutils.decrypt(encryptionKey, masterKeyNonce, getConfigValue(STR_MASTER_KEY), null);
 			} catch (InvalidCipherTextException e) {
 				logger.error("Cannot decrypt master key!", e);
+				return null;
 			}
 		}
 

--- a/src/main/java/de/qabel/core/exceptions/QblInvalidEncryptionKeyException.java
+++ b/src/main/java/de/qabel/core/exceptions/QblInvalidEncryptionKeyException.java
@@ -1,0 +1,4 @@
+package de.qabel.core.exceptions;
+
+public class QblInvalidEncryptionKeyException extends QblException {
+}

--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -7,6 +7,7 @@ import de.qabel.core.drop.*;
 import de.qabel.core.exceptions.QblDropInvalidURL;
 import de.qabel.core.exceptions.QblDropPayloadSizeException;
 
+import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,7 +65,7 @@ public class MultiPartCryptoTest {
     private Identity alice;
 
     @Before
-    public void setUp() throws InvalidKeyException, URISyntaxException, QblDropInvalidURL, InterruptedException, InstantiationException, IllegalAccessException {
+    public void setUp() throws InvalidKeyException, URISyntaxException, QblDropInvalidURL, InterruptedException, InstantiationException, IllegalAccessException, QblInvalidEncryptionKeyException {
         Persistence<String> persistence = new SQLitePersistence(DB_NAME, encryptionPassword);
 		resourceActor = new ResourceActor(persistence, EventEmitter.getDefault());
 		resourceActorThread = new Thread(resourceActor);

--- a/src/test/java/de/qabel/core/config/PersistenceTest.java
+++ b/src/test/java/de/qabel/core/config/PersistenceTest.java
@@ -1,5 +1,6 @@
 package de.qabel.core.config;
 
+import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
 import org.junit.*;
 
 import java.io.File;
@@ -12,7 +13,7 @@ public class PersistenceTest {
 	Persistence<String> persistence;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws QblInvalidEncryptionKeyException {
 		persistence = new SQLitePersistence(DB_NAME, encryptionPassword);
 	}
 
@@ -22,6 +23,11 @@ public class PersistenceTest {
 		if(persistenceTestDB.exists()) {
 			persistenceTestDB.delete();
 		}
+	}
+
+	@Test(expected=QblInvalidEncryptionKeyException.class)
+	public void openWithWrongPasswordTest() throws QblInvalidEncryptionKeyException {
+		persistence = new SQLitePersistence(DB_NAME, "wrongPassword".toCharArray());
 	}
 
 	@Test

--- a/src/test/java/de/qabel/core/config/ResourceActorTest.java
+++ b/src/test/java/de/qabel/core/config/ResourceActorTest.java
@@ -14,6 +14,7 @@ import de.qabel.ackack.event.EventListener;
 import de.qabel.core.EventNameConstants;
 import de.qabel.core.drop.DropURL;
 import de.qabel.core.exceptions.QblDropInvalidURL;
+import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,7 +48,7 @@ public class ResourceActorTest {
 	final TestActor testActor = new TestActor();
 
 	@Before
-	public void setUp() {
+	public void setUp() throws QblInvalidEncryptionKeyException {
 		Persistence<String> persistence = new SQLitePersistence(DB_NAME, encryptionPassword);
 		resourceActor = new ResourceActor(persistence, EventEmitter.getDefault());
 		accountFactory = new AccountTestFactory();

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -6,6 +6,7 @@ import de.qabel.core.crypto.*;
 import de.qabel.core.exceptions.QblDropInvalidURL;
 import de.qabel.core.exceptions.QblDropPayloadSizeException;
 
+import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
 import org.junit.*;
 
 import java.io.File;
@@ -37,7 +38,7 @@ public class DropActorTest {
     }
 
     @Before
-    public void setup() throws URISyntaxException, QblDropInvalidURL, InvalidKeyException, InterruptedException, InstantiationException, IllegalAccessException {
+    public void setup() throws URISyntaxException, QblDropInvalidURL, InvalidKeyException, InterruptedException, InstantiationException, IllegalAccessException, QblInvalidEncryptionKeyException {
 		Persistence<String> persistence = new SQLitePersistence(DB_NAME, encryptionPassword);
 		resourceActor = new ResourceActor(persistence, EventEmitter.getDefault());
 		resourceActorThread = new Thread(resourceActor);


### PR DESCRIPTION
I discovered, that instantiating a persistence with a wrong encryption password isn't handled very well. This adds an exception for this case.

Requires: https://github.com/Qabel/qabel-desktop/pull/24