### PR TITLE
Fix enableAcknowledging in DropMessage

### DIFF
--- a/src/main/java/de/qabel/core/drop/DropMessage.java
+++ b/src/main/java/de/qabel/core/drop/DropMessage.java
@@ -94,8 +94,8 @@ public class DropMessage<T extends ModelObject> implements Serializable {
      *
      * @param enabled true enables acknowledging
      */
-    public void enableAcknowledgeing(boolean enabled) {
-    	if (enabled && this.acknowledgeId == NOACK) {
+    public void enableAcknowledging(boolean enabled) {
+    	if (enabled && this.acknowledgeId.equals(NOACK)) {
     		this.acknowledgeId = generateAcknowledgeId();
     	} else if (!enabled) {
     		this.acknowledgeId = NOACK;

--- a/src/test/java/de/qabel/core/drop/AcknowledgeIdGenerationTest.java
+++ b/src/test/java/de/qabel/core/drop/AcknowledgeIdGenerationTest.java
@@ -28,9 +28,9 @@ public class AcknowledgeIdGenerationTest {
 	@Test
 	public void testSwitchAck() {
 		DropMessage<DummyMessage> dm = new DropMessage<>(sender, new DummyMessage());
-		dm.enableAcknowledgeing(true);
+		dm.enableAcknowledging(true);
 		Assert.assertNotEquals(DropMessage.NOACK, dm.getAcknowledgeID());
-		dm.enableAcknowledgeing(false);
+		dm.enableAcknowledging(false);
 		Assert.assertEquals(DropMessage.NOACK, dm.getAcknowledgeID());
 	}
 }


### PR DESCRIPTION
* The method name had a spelling error
* == instead of equals was used for String comparison