### PR TITLE
Fix gradle build without meta repo

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'qabel-core'
-include ':ackack'
+
+includeFlat 'ackack'


### PR DESCRIPTION
qable-core can be built without submodules and without needing the whole
meta qabel-repository.

The README.md includes up to date build instructions.