### PR TITLE
Qabel-Box

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ repositories {
 dependencies {
 	testCompile group: 'junit', name: 'junit', version: '4.+'
 	testCompile group: 'org.meanbean', name: 'meanbean', version: '2.+'
-	compile 'com.google.code.gson:gson:2.+' 
-	compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.51'
+	compile 'com.google.code.gson:gson:2.+'
+	compile group: 'com.madgag.spongycastle', name: 'prov', version: '1.52.0.0'
 	compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'
 	compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.4'
 	compile group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.4'

--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -2,8 +2,8 @@ package de.qabel.core.config;
 
 import de.qabel.core.crypto.CryptoUtils;
 import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
-import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.crypto.params.KeyParameter;
+import org.spongycastle.crypto.InvalidCipherTextException;
+import org.spongycastle.crypto.params.KeyParameter;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -1,8 +1,8 @@
 package de.qabel.core.config;
 
 import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
-import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.crypto.params.KeyParameter;
+import org.spongycastle.crypto.InvalidCipherTextException;
+import org.spongycastle.crypto.params.KeyParameter;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 

--- a/src/main/java/de/qabel/core/crypto/BinaryDropMessageV0.java
+++ b/src/main/java/de/qabel/core/crypto/BinaryDropMessageV0.java
@@ -13,8 +13,8 @@ import de.qabel.core.drop.DropMessage;
 import de.qabel.core.exceptions.QblDropInvalidMessageSizeException;
 import de.qabel.core.exceptions.QblDropPayloadSizeException;
 import de.qabel.core.exceptions.QblVersionMismatchException;
-import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.util.encoders.Hex;
+import org.spongycastle.crypto.InvalidCipherTextException;
+import org.spongycastle.util.encoders.Hex;
 
 /**
  * Drop message in binary transport format version 0

--- a/src/main/java/de/qabel/core/crypto/CryptoUtils.java
+++ b/src/main/java/de/qabel/core/crypto/CryptoUtils.java
@@ -30,18 +30,18 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.crypto.engines.AESEngine;
-import org.bouncycastle.crypto.modes.GCMBlockCipher;
-import org.bouncycastle.crypto.params.AEADParameters;
-import org.bouncycastle.crypto.params.KeyParameter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.spongycastle.crypto.InvalidCipherTextException;
+import org.spongycastle.crypto.engines.AESEngine;
+import org.spongycastle.crypto.modes.GCMBlockCipher;
+import org.spongycastle.crypto.params.AEADParameters;
+import org.spongycastle.crypto.params.KeyParameter;
+import org.spongycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.*;
 
 public class CryptoUtils {
 
 	// https://github.com/Qabel/qabel-doc/wiki/Components-Crypto
-	private final static String CRYPTOGRAPHIC_PROVIDER = "BC"; // BouncyCastle
+	private final static String CRYPTOGRAPHIC_PROVIDER = "SC"; // SpongyCastle
 	private final static String SYMM_KEY_ALGORITHM = "AES";
 	private final static String SYMM_GCM_TRANSFORMATION = "AES/GCM/NoPadding";
 	private final static int SYMM_GCM_READ_SIZE_BYTE = 4096; // Should be multiple of 4096 byte due to flash block size.
@@ -68,11 +68,13 @@ public class CryptoUtils {
 	private Mac hmac;
 	private KeyGenerator keyGenerator;
 
+	static {
+		Security.insertProviderAt(new BouncyCastleProvider(), 1);
+	}
+
 	public CryptoUtils() {
 
 		try {
-			Security.addProvider(new BouncyCastleProvider());
-
 			secRandom = new SecureRandom();
 			gcmCipher = Cipher.getInstance(SYMM_GCM_TRANSFORMATION,
 					CRYPTOGRAPHIC_PROVIDER);
@@ -426,7 +428,7 @@ public class CryptoUtils {
 	 * 		plaintext which is the content of the received noise box
 	 * @throws java.security.InvalidKeyException
 	 * 		if kdf cannot distribute a key from DH of given EC keys
-	 * @throws org.bouncycastle.crypto.InvalidCipherTextException
+	 * @throws org.spongycastle.crypto.InvalidCipherTextException
 	 * 		on decryption errors
 	 */
 	public DecryptedPlaintext readBox(QblECKeyPair targetKey, byte[] noiseBox) throws InvalidKeyException, InvalidCipherTextException {
@@ -521,7 +523,7 @@ public class CryptoUtils {
 	 * @param plaintext plaintext to encrypt
 	 * @param associatedData additionally associated data
 	 * @return encrypted plaintext
-	 * @throws org.bouncycastle.crypto.InvalidCipherTextException on encryption errors
+	 * @throws org.spongycastle.crypto.InvalidCipherTextException on encryption errors
 	 */
 	public byte[] encrypt(KeyParameter key, byte[] nonce, byte[] plaintext, byte[] associatedData) throws InvalidCipherTextException {
 		AEADParameters params = new AEADParameters(key, MAC_BIT, nonce, associatedData);
@@ -541,7 +543,7 @@ public class CryptoUtils {
 	 * @param ciphertext ciphertext to encrypt
 	 * @param associatedData additionally associated data
 	 * @return encrypted ciphertext
-	 * @throws org.bouncycastle.crypto.InvalidCipherTextException on decryption errors
+	 * @throws org.spongycastle.crypto.InvalidCipherTextException on decryption errors
 	 */
 	public byte[] decrypt(KeyParameter key, byte[] nonce, byte[] ciphertext, byte[] associatedData) throws InvalidCipherTextException {
 		AEADParameters params = new AEADParameters(key, MAC_BIT, nonce, associatedData);

--- a/src/main/java/de/qabel/core/crypto/QblECPublicKey.java
+++ b/src/main/java/de/qabel/core/crypto/QblECPublicKey.java
@@ -1,6 +1,6 @@
 package de.qabel.core.crypto;
 
-import org.bouncycastle.util.encoders.Hex;
+import org.spongycastle.util.encoders.Hex;
 
 import java.io.Serializable;
 import java.util.Arrays;

--- a/src/main/java/de/qabel/core/crypto/QblEcKeyPairTypeAdapter.java
+++ b/src/main/java/de/qabel/core/crypto/QblEcKeyPairTypeAdapter.java
@@ -6,7 +6,7 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import org.bouncycastle.util.encoders.Hex;
+import org.spongycastle.util.encoders.Hex;
 
 public class QblEcKeyPairTypeAdapter extends TypeAdapter<QblECKeyPair> {
 

--- a/src/main/java/de/qabel/core/crypto/QblEcPublicKeyTypeAdapter.java
+++ b/src/main/java/de/qabel/core/crypto/QblEcPublicKeyTypeAdapter.java
@@ -10,7 +10,7 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import org.bouncycastle.util.encoders.Hex;
+import org.spongycastle.util.encoders.Hex;
 
 public class QblEcPublicKeyTypeAdapter extends TypeAdapter<QblECPublicKey> {
 

--- a/src/main/java/de/qabel/core/drop/DropIdGenerator.java
+++ b/src/main/java/de/qabel/core/drop/DropIdGenerator.java
@@ -2,7 +2,7 @@ package de.qabel.core.drop;
 
 import java.util.Arrays;
 
-import org.bouncycastle.util.encoders.UrlBase64;
+import org.spongycastle.util.encoders.UrlBase64;
 
 public abstract class DropIdGenerator {
 	/**

--- a/src/main/java/de/qabel/core/drop/DropURL.java
+++ b/src/main/java/de/qabel/core/drop/DropURL.java
@@ -4,8 +4,8 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.bouncycastle.util.encoders.DecoderException;
-import org.bouncycastle.util.encoders.UrlBase64;
+import org.spongycastle.util.encoders.DecoderException;
+import org.spongycastle.util.encoders.UrlBase64;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 

--- a/src/main/java/de/qabel/core/exceptions/QblException.java
+++ b/src/main/java/de/qabel/core/exceptions/QblException.java
@@ -14,4 +14,8 @@ public abstract class QblException extends Exception {
 	public QblException(String msg) {
 		super(msg);
 	}
+
+	public QblException(Throwable cause) {
+		super(cause);
+	}
 }

--- a/src/main/java/de/qabel/core/exceptions/QblStorageException.java
+++ b/src/main/java/de/qabel/core/exceptions/QblStorageException.java
@@ -1,0 +1,11 @@
+package de.qabel.core.exceptions;
+
+public class QblStorageException extends QblException{
+	public QblStorageException(Throwable e) {
+		super(e);
+	}
+
+	public QblStorageException(String s) {
+		super(s);
+	}
+}

--- a/src/main/java/de/qabel/core/exceptions/QblStorageNameConflict.java
+++ b/src/main/java/de/qabel/core/exceptions/QblStorageNameConflict.java
@@ -1,0 +1,11 @@
+package de.qabel.core.exceptions;
+
+public class QblStorageNameConflict extends QblStorageException {
+	public QblStorageNameConflict(Throwable e) {
+		super(e);
+	}
+
+	public QblStorageNameConflict(String s) {
+		super(s);
+	}
+}

--- a/src/main/java/de/qabel/core/exceptions/QblStorageNotFound.java
+++ b/src/main/java/de/qabel/core/exceptions/QblStorageNotFound.java
@@ -1,0 +1,12 @@
+package de.qabel.core.exceptions;
+
+public class QblStorageNotFound extends QblStorageException {
+
+	public QblStorageNotFound(Throwable e) {
+		super(e);
+	}
+
+	public QblStorageNotFound(String s) {
+		super(s);
+	}
+}

--- a/src/main/java/de/qabel/core/storage/AbstractNavigation.java
+++ b/src/main/java/de/qabel/core/storage/AbstractNavigation.java
@@ -46,7 +46,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		try {
 			InputStream indexDl = readBackend.download(target.ref);
 			tmp = Files.createTempFile(null, null);
-			SecretKey key = new SecretKeySpec(target.key, "AES");
+			SecretKey key = makeKey(target.key);
 			if (cryptoUtils.decryptFileAuthenticatedSymmetricAndValidateTag(indexDl, tmp.toFile(), key)) {
 				DirectoryMetadata dm = DirectoryMetadata.openDatabase(tmp, deviceId, target.ref);
 				return new FolderNavigation(dm, keyPair, target.key, deviceId, readBackend, writeBackend);
@@ -56,6 +56,10 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		} catch (IOException | InvalidKeyException e) {
 			throw new QblStorageException(e);
 		}
+	}
+
+	private SecretKey makeKey(byte[] key2) {
+		return new SecretKeySpec(key2, "AES");
 	}
 
 	@Override
@@ -106,7 +110,7 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	public InputStream download(BoxFile boxFile) throws QblStorageException {
 		InputStream download = readBackend.download(boxFile.block);
 		File temp;
-		SecretKey key = new SecretKeySpec(boxFile.key, "AES");
+		SecretKey key = makeKey(boxFile.key);
 		try {
 			temp = Files.createTempFile("", "").toFile();
 			if (!cryptoUtils.decryptFileAuthenticatedSymmetricAndValidateTag(download, temp, key)) {

--- a/src/main/java/de/qabel/core/storage/AbstractNavigation.java
+++ b/src/main/java/de/qabel/core/storage/AbstractNavigation.java
@@ -1,0 +1,117 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.crypto.CryptoUtils;
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.exceptions.QblStorageException;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.util.List;
+import java.util.UUID;
+
+public abstract class AbstractNavigation implements BoxNavigation {
+
+	DirectoryMetadata dm;
+	QblECKeyPair keyPair;
+	byte[] deviceId;
+	CryptoUtils cryptoUtils;
+
+	StorageReadBackend readBackend;
+	StorageWriteBackend writeBackend;
+
+
+	AbstractNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] deviceId,
+	                   StorageReadBackend readBackend, StorageWriteBackend writeBackend) {
+		this.dm = dm;
+		this.keyPair = keyPair;
+		this.deviceId = deviceId;
+		this.readBackend = readBackend;
+		this.writeBackend = writeBackend;
+		cryptoUtils = new CryptoUtils();
+	}
+
+	@Override
+	public BoxNavigation navigate(BoxFolder target) {
+		return null;
+	}
+
+	@Override
+	public BoxNavigation navigate(BoxExternal target) {
+		return null;
+	}
+
+	@Override
+	public List<BoxFile> listFiles() throws QblStorageException {
+		return dm.listFiles();
+	}
+
+	@Override
+	public List<BoxFolder> listFolder() throws QblStorageException {
+		return dm.listFolders();
+	}
+
+	@Override
+	public List<BoxExternal> listExternals() throws QblStorageException {
+		return dm.listExternals();
+	}
+
+	@Override
+	public BoxFile upload(String name, File file) throws QblStorageException {
+		SecretKey key = cryptoUtils.generateSymmetricKey();
+		String block = UUID.randomUUID().toString();
+		BoxFile boxFile = new BoxFile(block, name, file.length(), 0l, key.getEncoded());
+		boxFile.mtime = uploadEncrypted(file, key, block);
+		dm.insertFile(boxFile);
+		return boxFile;
+	}
+
+	protected long uploadEncrypted(File file, SecretKey key, String block) throws QblStorageException {
+		try {
+			Path tempFile = Files.createTempFile("", "");
+			OutputStream outputStream = Files.newOutputStream(tempFile);
+			cryptoUtils.encryptFileAuthenticatedSymmetric(file, outputStream, key);
+			return writeBackend.upload(block, Files.newInputStream(tempFile));
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		}
+		 catch (InvalidKeyException e) {
+			 throw new QblStorageException(e);
+		 }
+	}
+
+	@Override
+	public InputStream download(String name) throws QblStorageException {
+		BoxFile boxFile = dm.getFile(name);
+		InputStream download = readBackend.download(boxFile.block);
+		File temp;
+		SecretKey key = new SecretKeySpec(boxFile.key, "AES");
+		try {
+			temp = Files.createTempFile("", "").toFile();
+			cryptoUtils.decryptFileAuthenticatedSymmetricAndValidateTag(download, temp, key);
+			return Files.newInputStream(temp.toPath());
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		} catch (InvalidKeyException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	@Override
+	public void delete(BoxFile file) throws QblStorageException {
+
+	}
+
+	@Override
+	public void delete(BoxFolder folder) throws QblStorageException {
+
+	}
+
+	@Override
+	public void delete(BoxExternal external) throws QblStorageException {
+
+	}
+}

--- a/src/main/java/de/qabel/core/storage/AbstractNavigation.java
+++ b/src/main/java/de/qabel/core/storage/AbstractNavigation.java
@@ -88,6 +88,12 @@ public abstract class AbstractNavigation implements BoxNavigation {
 		String block = UUID.randomUUID().toString();
 		BoxFile boxFile = new BoxFile(block, name, file.length(), 0l, key.getEncoded());
 		boxFile.mtime = uploadEncrypted(file, key, block);
+		// Overwrite = delete old file, upload new file
+		BoxFile oldFile = dm.getFile(name);
+		if (oldFile != null) {
+			writeBackend.delete(oldFile.block);
+			dm.deleteFile(oldFile);
+		}
 		dm.insertFile(boxFile);
 		return boxFile;
 	}

--- a/src/main/java/de/qabel/core/storage/AbstractNavigation.java
+++ b/src/main/java/de/qabel/core/storage/AbstractNavigation.java
@@ -71,12 +71,12 @@ public abstract class AbstractNavigation implements BoxNavigation {
 	public void commit() throws QblStorageException {
 		byte[] version = dm.getVersion();
 		dm.commit();
-		logger.info("Committing version "+ Hex.encodeHexString(dm.getVersion())
-				+ " with device id " + Hex.encodeHexString(dm.deviceId));
+		logger.info("Committing version "+ new String(Hex.encodeHex(dm.getVersion()))
+				+ " with device id " + new String(Hex.encodeHex(dm.deviceId)));
 		DirectoryMetadata updatedDM = null;
 		try {
 			updatedDM = reloadMetadata();
-			logger.info("Remote version is " + Hex.encodeHexString(updatedDM.getVersion()));
+			logger.info("Remote version is " + new String(Hex.encodeHex(updatedDM.getVersion())));
 		} catch (QblStorageNotFound e) {
 			logger.info("Could not reload metadata");
 		}

--- a/src/main/java/de/qabel/core/storage/AndroidBoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/AndroidBoxVolume.java
@@ -1,0 +1,22 @@
+package de.qabel.core.storage;
+
+import com.amazonaws.auth.AWSCredentials;
+import de.qabel.core.crypto.QblECKeyPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class AndroidBoxVolume extends BoxVolume {
+	private static final Logger logger = LoggerFactory.getLogger(AndroidBoxVolume.class.getName());
+
+	public AndroidBoxVolume(String bucket, String prefix, AWSCredentials credentials, QblECKeyPair keyPair, byte[] deviceId, File tempDir) {
+		super(bucket, prefix, credentials, keyPair, deviceId, tempDir);
+	}
+
+	@Override
+	protected void loadDriver() throws ClassNotFoundException {
+		logger.info("Loading Android sqlite driver");
+		Class.forName("org.sqldroid.SQLDroidDriver");
+	}
+}

--- a/src/main/java/de/qabel/core/storage/BoxExternal.java
+++ b/src/main/java/de/qabel/core/storage/BoxExternal.java
@@ -1,0 +1,4 @@
+package de.qabel.core.storage;
+
+class BoxExternal {
+}

--- a/src/main/java/de/qabel/core/storage/BoxExternal.java
+++ b/src/main/java/de/qabel/core/storage/BoxExternal.java
@@ -1,4 +1,42 @@
 package de.qabel.core.storage;
 
+import de.qabel.core.crypto.QblECPublicKey;
+
+import java.util.Arrays;
+
 class BoxExternal {
+	String url;
+	String name;
+	QblECPublicKey owner;
+	byte[] key;
+
+	public BoxExternal(String url, String name, QblECPublicKey owner, byte[] key) {
+		this.url = url;
+		this.name = name;
+		this.owner = owner;
+		this.key = key;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		BoxExternal that = (BoxExternal) o;
+
+		if (url != null ? !url.equals(that.url) : that.url != null) return false;
+		if (name != null ? !name.equals(that.name) : that.name != null) return false;
+		if (owner != null ? !owner.equals(that.owner) : that.owner != null) return false;
+		return Arrays.equals(key, that.key);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = url != null ? url.hashCode() : 0;
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		result = 31 * result + (owner != null ? owner.hashCode() : 0);
+		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
+		return result;
+	}
 }

--- a/src/main/java/de/qabel/core/storage/BoxExternal.java
+++ b/src/main/java/de/qabel/core/storage/BoxExternal.java
@@ -4,7 +4,7 @@ import de.qabel.core.crypto.QblECPublicKey;
 
 import java.util.Arrays;
 
-class BoxExternal {
+public class BoxExternal {
 	String url;
 	String name;
 	QblECPublicKey owner;

--- a/src/main/java/de/qabel/core/storage/BoxExternal.java
+++ b/src/main/java/de/qabel/core/storage/BoxExternal.java
@@ -5,10 +5,10 @@ import de.qabel.core.crypto.QblECPublicKey;
 import java.util.Arrays;
 
 public class BoxExternal {
-	String url;
-	String name;
-	QblECPublicKey owner;
-	byte[] key;
+	public String url;
+	public String name;
+	public QblECPublicKey owner;
+	public byte[] key;
 
 	public BoxExternal(String url, String name, QblECPublicKey owner, byte[] key) {
 		this.url = url;

--- a/src/main/java/de/qabel/core/storage/BoxFile.java
+++ b/src/main/java/de/qabel/core/storage/BoxFile.java
@@ -3,11 +3,11 @@ package de.qabel.core.storage;
 import java.util.Arrays;
 
 public class BoxFile {
-	String block;
-	String name;
-	Long size;
-	Long mtime;
-	byte[] key;
+	public String block;
+	public String name;
+	public Long size;
+	public Long mtime;
+	public byte[] key;
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/de/qabel/core/storage/BoxFile.java
+++ b/src/main/java/de/qabel/core/storage/BoxFile.java
@@ -1,0 +1,4 @@
+package de.qabel.core.storage;
+
+class BoxFile {
+}

--- a/src/main/java/de/qabel/core/storage/BoxFile.java
+++ b/src/main/java/de/qabel/core/storage/BoxFile.java
@@ -2,7 +2,7 @@ package de.qabel.core.storage;
 
 import java.util.Arrays;
 
-class BoxFile {
+public class BoxFile {
 	String block;
 	String name;
 	Long size;

--- a/src/main/java/de/qabel/core/storage/BoxFile.java
+++ b/src/main/java/de/qabel/core/storage/BoxFile.java
@@ -1,4 +1,44 @@
 package de.qabel.core.storage;
 
+import java.util.Arrays;
+
 class BoxFile {
+	String block;
+	String name;
+	Long size;
+	Long mtime;
+	byte[] key;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		BoxFile boxFile = (BoxFile) o;
+
+		if (block != null ? !block.equals(boxFile.block) : boxFile.block != null) return false;
+		if (name != null ? !name.equals(boxFile.name) : boxFile.name != null) return false;
+		if (size != null ? !size.equals(boxFile.size) : boxFile.size != null) return false;
+		if (mtime != null ? !mtime.equals(boxFile.mtime) : boxFile.mtime != null) return false;
+		return Arrays.equals(key, boxFile.key);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = block != null ? block.hashCode() : 0;
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		result = 31 * result + (size != null ? size.hashCode() : 0);
+		result = 31 * result + (mtime != null ? mtime.hashCode() : 0);
+		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
+		return result;
+	}
+
+	public BoxFile(String block, String name, Long size, Long mtime, byte[] key) {
+		this.block = block;
+		this.name = name;
+		this.size = size;
+		this.mtime = mtime;
+		this.key = key;
+	}
 }

--- a/src/main/java/de/qabel/core/storage/BoxFile.java
+++ b/src/main/java/de/qabel/core/storage/BoxFile.java
@@ -2,9 +2,8 @@ package de.qabel.core.storage;
 
 import java.util.Arrays;
 
-public class BoxFile {
+public class BoxFile extends BoxObject {
 	public String block;
-	public String name;
 	public Long size;
 	public Long mtime;
 	public byte[] key;
@@ -35,8 +34,8 @@ public class BoxFile {
 	}
 
 	public BoxFile(String block, String name, Long size, Long mtime, byte[] key) {
+		super(name);
 		this.block = block;
-		this.name = name;
 		this.size = size;
 		this.mtime = mtime;
 		this.key = key;

--- a/src/main/java/de/qabel/core/storage/BoxFolder.java
+++ b/src/main/java/de/qabel/core/storage/BoxFolder.java
@@ -2,7 +2,7 @@ package de.qabel.core.storage;
 
 import java.util.Arrays;
 
-class BoxFolder {
+public class BoxFolder {
 	String name;
 	byte[] key;
 	String ref;

--- a/src/main/java/de/qabel/core/storage/BoxFolder.java
+++ b/src/main/java/de/qabel/core/storage/BoxFolder.java
@@ -1,0 +1,4 @@
+package de.qabel.core.storage;
+
+class BoxFolder {
+}

--- a/src/main/java/de/qabel/core/storage/BoxFolder.java
+++ b/src/main/java/de/qabel/core/storage/BoxFolder.java
@@ -1,4 +1,38 @@
 package de.qabel.core.storage;
 
+import java.util.Arrays;
+
 class BoxFolder {
+	String name;
+	byte[] key;
+	String ref;
+
+	public BoxFolder(String ref, String name, byte[] key) {
+		this.name = name;
+		this.key = key;
+		this.ref = ref;
+	}
+
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		BoxFolder boxFolder = (BoxFolder) o;
+
+		if (name != null ? !name.equals(boxFolder.name) : boxFolder.name != null) return false;
+		if (!Arrays.equals(key, boxFolder.key)) return false;
+		return !(ref != null ? !ref.equals(boxFolder.ref) : boxFolder.ref != null);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = name != null ? name.hashCode() : 0;
+		result = 31 * result + (key != null ? Arrays.hashCode(key) : 0);
+		result = 31 * result + (ref != null ? ref.hashCode() : 0);
+		return result;
+	}
+
 }

--- a/src/main/java/de/qabel/core/storage/BoxFolder.java
+++ b/src/main/java/de/qabel/core/storage/BoxFolder.java
@@ -3,9 +3,9 @@ package de.qabel.core.storage;
 import java.util.Arrays;
 
 public class BoxFolder {
-	String name;
-	byte[] key;
-	String ref;
+	public String name;
+	public byte[] key;
+	public String ref;
 
 	public BoxFolder(String ref, String name, byte[] key) {
 		this.name = name;

--- a/src/main/java/de/qabel/core/storage/BoxFolder.java
+++ b/src/main/java/de/qabel/core/storage/BoxFolder.java
@@ -2,13 +2,12 @@ package de.qabel.core.storage;
 
 import java.util.Arrays;
 
-public class BoxFolder {
-	public String name;
+public class BoxFolder extends BoxObject {
 	public byte[] key;
 	public String ref;
 
 	public BoxFolder(String ref, String name, byte[] key) {
-		this.name = name;
+		super(name);
 		this.key = key;
 		this.ref = ref;
 	}

--- a/src/main/java/de/qabel/core/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/core/storage/BoxNavigation.java
@@ -8,6 +8,13 @@ import java.util.List;
 
 public interface BoxNavigation {
 
+	/**
+	 * Bumps the version and uploads the metadata file
+	 *
+	 * All actions are not guaranteed to be finished before the commit
+	 * method returned.
+	 * @throws QblStorageException
+	 */
 	void commit() throws QblStorageException;
 
 	BoxNavigation navigate(BoxFolder target) throws QblStorageException;

--- a/src/main/java/de/qabel/core/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/core/storage/BoxNavigation.java
@@ -10,15 +10,17 @@ public interface BoxNavigation {
 
 	void commit() throws QblStorageException;
 
-	BoxNavigation navigate(BoxFolder target);
+	BoxNavigation navigate(BoxFolder target) throws QblStorageException;
 	BoxNavigation navigate(BoxExternal target);
 
 	List<BoxFile> listFiles() throws QblStorageException;
-	List<BoxFolder> listFolder() throws QblStorageException;
+	List<BoxFolder> listFolders() throws QblStorageException;
 	List<BoxExternal> listExternals() throws QblStorageException;
 
 	BoxFile upload(String name, File file) throws QblStorageException;
 	InputStream download(String name) throws QblStorageException;
+
+	BoxFolder createFolder(String name) throws QblStorageException;
 
 	void delete(BoxFile file) throws QblStorageException;
 	void delete(BoxFolder folder) throws QblStorageException;

--- a/src/main/java/de/qabel/core/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/core/storage/BoxNavigation.java
@@ -18,7 +18,7 @@ public interface BoxNavigation {
 	List<BoxExternal> listExternals() throws QblStorageException;
 
 	BoxFile upload(String name, File file) throws QblStorageException;
-	InputStream download(String name) throws QblStorageException;
+	InputStream download(BoxFile file) throws QblStorageException;
 
 	BoxFolder createFolder(String name) throws QblStorageException;
 

--- a/src/main/java/de/qabel/core/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/core/storage/BoxNavigation.java
@@ -1,0 +1,22 @@
+package de.qabel.core.storage;
+
+import java.io.InputStream;
+import java.util.List;
+
+public interface BoxNavigation {
+
+	BoxNavigation navigate(BoxFolder target);
+	BoxNavigation navigate(BoxExternal target);
+
+	List<BoxFile> listFiles();
+	List<BoxFolder> listFolder();
+	List<BoxExternal> listExternals();
+
+	BoxFile upload(String name, InputStream content);
+	InputStream download(BoxFile file);
+
+	void delete(BoxFile file);
+	void delete(BoxFolder folder);
+	void delete(BoxExternal external);
+
+}

--- a/src/main/java/de/qabel/core/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/core/storage/BoxNavigation.java
@@ -2,10 +2,13 @@ package de.qabel.core.storage;
 
 import de.qabel.core.exceptions.QblStorageException;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 
 public interface BoxNavigation {
+
+	void commit() throws QblStorageException;
 
 	BoxNavigation navigate(BoxFolder target);
 	BoxNavigation navigate(BoxExternal target);
@@ -14,8 +17,8 @@ public interface BoxNavigation {
 	List<BoxFolder> listFolder() throws QblStorageException;
 	List<BoxExternal> listExternals() throws QblStorageException;
 
-	BoxFile upload(String name, InputStream content) throws QblStorageException;
-	InputStream download(BoxFile file) throws QblStorageException;
+	BoxFile upload(String name, File file) throws QblStorageException;
+	InputStream download(String name) throws QblStorageException;
 
 	void delete(BoxFile file) throws QblStorageException;
 	void delete(BoxFolder folder) throws QblStorageException;

--- a/src/main/java/de/qabel/core/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/core/storage/BoxNavigation.java
@@ -1,5 +1,7 @@
 package de.qabel.core.storage;
 
+import de.qabel.core.exceptions.QblStorageException;
+
 import java.io.InputStream;
 import java.util.List;
 
@@ -8,15 +10,15 @@ public interface BoxNavigation {
 	BoxNavigation navigate(BoxFolder target);
 	BoxNavigation navigate(BoxExternal target);
 
-	List<BoxFile> listFiles();
-	List<BoxFolder> listFolder();
-	List<BoxExternal> listExternals();
+	List<BoxFile> listFiles() throws QblStorageException;
+	List<BoxFolder> listFolder() throws QblStorageException;
+	List<BoxExternal> listExternals() throws QblStorageException;
 
-	BoxFile upload(String name, InputStream content);
-	InputStream download(BoxFile file);
+	BoxFile upload(String name, InputStream content) throws QblStorageException;
+	InputStream download(BoxFile file) throws QblStorageException;
 
-	void delete(BoxFile file);
-	void delete(BoxFolder folder);
-	void delete(BoxExternal external);
+	void delete(BoxFile file) throws QblStorageException;
+	void delete(BoxFolder folder) throws QblStorageException;
+	void delete(BoxExternal external) throws QblStorageException;
 
 }

--- a/src/main/java/de/qabel/core/storage/BoxObject.java
+++ b/src/main/java/de/qabel/core/storage/BoxObject.java
@@ -1,0 +1,21 @@
+package de.qabel.core.storage;
+
+public class BoxObject implements Comparable<BoxObject>  {
+	public String name;
+
+	public BoxObject(String name) {this.name = name;}
+
+	@Override
+	public int compareTo(BoxObject another) {
+		if (this instanceof BoxFile && another instanceof BoxFile) {
+			return this.name.compareTo(another.name);
+		}
+		if (this instanceof BoxFolder && another instanceof BoxFolder) {
+			return this.name.compareTo(another.name);
+		}
+		if (this instanceof BoxFile) {
+			return -1;
+		}
+		return 1;
+	}
+}

--- a/src/main/java/de/qabel/core/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/BoxVolume.java
@@ -2,13 +2,16 @@ package de.qabel.core.storage;
 
 import com.amazonaws.auth.AWSCredentials;
 import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.exceptions.QblStorageException;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.UUID;
 
 public class BoxVolume {
 
-	Map<String, DirectoryMetadata> cache = new HashMap<>();
 	StorageReadBackend readBackend;
 	StorageWriteBackend writeBackend;
 
@@ -27,5 +30,23 @@ public class BoxVolume {
 		this.writeBackend = writeBackend;
 	}
 
+	public BoxNavigation navigate() {
+		return null;
+	}
 
+
+	public String getRootRef() throws QblStorageException {
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new QblStorageException(e);
+		}
+		md.update(keyPair.getPrivateKey());
+		byte[] digest = md.digest();
+		byte[] firstBytes = Arrays.copyOfRange(digest, 0, 16);
+		ByteBuffer bb = ByteBuffer.wrap(firstBytes);
+		UUID uuid = new UUID(bb.getLong(), bb.getLong());
+		return uuid.toString();
+	}
 }

--- a/src/main/java/de/qabel/core/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/BoxVolume.java
@@ -7,6 +7,8 @@ import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,6 +24,8 @@ import java.util.Arrays;
 import java.util.UUID;
 
 public class BoxVolume {
+
+	private static final Logger logger = LoggerFactory.getLogger(BoxVolume.class.getName());
 
 	StorageReadBackend readBackend;
 	StorageWriteBackend writeBackend;
@@ -50,6 +54,7 @@ public class BoxVolume {
 
 	public BoxNavigation navigate() throws QblStorageException {
 		String rootRef = getRootRef();
+		logger.info("Navigating to " + rootRef);
 		InputStream indexDl = readBackend.download(rootRef);
 		Path tmp;
 		try {

--- a/src/main/java/de/qabel/core/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/BoxVolume.java
@@ -6,7 +6,7 @@ import de.qabel.core.crypto.DecryptedPlaintext;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
 import org.apache.commons.io.IOUtils;
-import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.spongycastle.crypto.InvalidCipherTextException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/de/qabel/core/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/BoxVolume.java
@@ -1,10 +1,21 @@
 package de.qabel.core.storage;
 
 import com.amazonaws.auth.AWSCredentials;
+import de.qabel.core.crypto.CryptoUtils;
+import de.qabel.core.crypto.DecryptedPlaintext;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.crypto.InvalidCipherTextException;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -16,24 +27,44 @@ public class BoxVolume {
 	StorageWriteBackend writeBackend;
 
 	private QblECKeyPair keyPair;
+	private byte[] deviceId;
+	private CryptoUtils cryptoUtils;
 
-	public BoxVolume(String bucket, String prefix, AWSCredentials credentials, QblECKeyPair keyPair) {
+	public BoxVolume(String bucket, String prefix, AWSCredentials credentials,
+	                 QblECKeyPair keyPair, byte[] deviceId) {
 		this.keyPair = keyPair;
+		this.deviceId = deviceId;
 		readBackend = new S3ReadBackend(bucket, prefix);
 		writeBackend = new S3WriteBackend(credentials, bucket, prefix);
+		cryptoUtils = new CryptoUtils();
 	}
 
 	public BoxVolume(StorageReadBackend readBackend, StorageWriteBackend writeBackend,
-	                 QblECKeyPair keyPair) {
+	                 QblECKeyPair keyPair, byte[] deviceId) {
 		this.keyPair = keyPair;
+		this.deviceId = deviceId;
 		this.readBackend = readBackend;
 		this.writeBackend = writeBackend;
+		cryptoUtils = new CryptoUtils();
 	}
 
-	public BoxNavigation navigate() {
-		return null;
+	public BoxNavigation navigate() throws QblStorageException {
+		InputStream indexDl = readBackend.download(getRootRef());
+		Path tmp;
+		try {
+			byte[] encrypted = IOUtils.toByteArray(indexDl);
+			DecryptedPlaintext plaintext = cryptoUtils.readBox(keyPair, encrypted);
+			// Should work fine for the small metafiles
+			tmp = Files.createTempFile(null, null);
+			OutputStream out = Files.newOutputStream(tmp);
+			out.write(plaintext.getPlaintext());
+			out.close();
+		} catch (IOException | InvalidCipherTextException | InvalidKeyException e) {
+			throw new QblStorageException(e);
+		}
+		DirectoryMetadata dm = DirectoryMetadata.openDatabase(tmp, deviceId);
+		return new FolderNavigation(dm, keyPair, deviceId);
 	}
-
 
 	public String getRootRef() throws QblStorageException {
 		MessageDigest md;
@@ -48,5 +79,25 @@ public class BoxVolume {
 		ByteBuffer bb = ByteBuffer.wrap(firstBytes);
 		UUID uuid = new UUID(bb.getLong(), bb.getLong());
 		return uuid.toString();
+	}
+
+	public void createIndex(String bucket, String prefix) throws QblStorageException {
+		createIndex("https://" + bucket + ".s3.amazonaws.com/" + prefix);
+	}
+
+	public void createIndex(String root) throws QblStorageException {
+		String rootRef = getRootRef();
+		DirectoryMetadata dm = DirectoryMetadata.newDatabase(root, deviceId);
+		try {
+			byte[] plaintext = Files.readAllBytes(dm.path);
+			byte[] encrypted = cryptoUtils.createBox(keyPair, keyPair.getPub(), plaintext, 0);
+			writeBackend.upload(rootRef, new ByteArrayInputStream(encrypted));
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		} catch (InvalidKeyException e) {
+			throw new QblStorageException(e);
+		}
+
+
 	}
 }

--- a/src/main/java/de/qabel/core/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/BoxVolume.java
@@ -49,7 +49,8 @@ public class BoxVolume {
 	}
 
 	public BoxNavigation navigate() throws QblStorageException {
-		InputStream indexDl = readBackend.download(getRootRef());
+		String rootRef = getRootRef();
+		InputStream indexDl = readBackend.download(rootRef);
 		Path tmp;
 		try {
 			byte[] encrypted = IOUtils.toByteArray(indexDl);
@@ -62,8 +63,8 @@ public class BoxVolume {
 		} catch (IOException | InvalidCipherTextException | InvalidKeyException e) {
 			throw new QblStorageException(e);
 		}
-		DirectoryMetadata dm = DirectoryMetadata.openDatabase(tmp, deviceId);
-		return new FolderNavigation(dm, keyPair, deviceId);
+		DirectoryMetadata dm = DirectoryMetadata.openDatabase(tmp, deviceId, rootRef);
+		return new IndexNavigation(dm, keyPair, deviceId, readBackend, writeBackend);
 	}
 
 	public String getRootRef() throws QblStorageException {

--- a/src/main/java/de/qabel/core/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/BoxVolume.java
@@ -1,0 +1,31 @@
+package de.qabel.core.storage;
+
+import com.amazonaws.auth.AWSCredentials;
+import de.qabel.core.crypto.QblECKeyPair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BoxVolume {
+
+	Map<String, DirectoryMetadata> cache = new HashMap<>();
+	StorageReadBackend readBackend;
+	StorageWriteBackend writeBackend;
+
+	private QblECKeyPair keyPair;
+
+	public BoxVolume(String bucket, String prefix, AWSCredentials credentials, QblECKeyPair keyPair) {
+		this.keyPair = keyPair;
+		readBackend = new S3ReadBackend(bucket, prefix);
+		writeBackend = new S3WriteBackend(credentials, bucket, prefix);
+	}
+
+	public BoxVolume(StorageReadBackend readBackend, StorageWriteBackend writeBackend,
+	                 QblECKeyPair keyPair) {
+		this.keyPair = keyPair;
+		this.readBackend = readBackend;
+		this.writeBackend = writeBackend;
+	}
+
+
+}

--- a/src/main/java/de/qabel/core/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/core/storage/BoxVolume.java
@@ -32,13 +32,8 @@ public class BoxVolume {
 
 	public BoxVolume(String bucket, String prefix, AWSCredentials credentials,
 	                 QblECKeyPair keyPair, byte[] deviceId, File tempDir) {
-		this.keyPair = keyPair;
-		this.deviceId = deviceId;
-		readBackend = new S3ReadBackend(bucket, prefix);
-		writeBackend = new S3WriteBackend(credentials, bucket, prefix);
-		cryptoUtils = new CryptoUtils();
-		this.tempDir = tempDir;
-
+		this(new S3ReadBackend(bucket, prefix), new S3WriteBackend(credentials, bucket, prefix),
+				keyPair, deviceId, tempDir);
 	}
 
 	public BoxVolume(StorageReadBackend readBackend, StorageWriteBackend writeBackend,
@@ -49,6 +44,16 @@ public class BoxVolume {
 		this.writeBackend = writeBackend;
 		cryptoUtils = new CryptoUtils();
 		this.tempDir = tempDir;
+		try {
+			loadDriver();
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected void loadDriver() throws ClassNotFoundException {
+		logger.info("Loading PC sqlite driver");
+		Class.forName("org.sqlite.JDBC");
 	}
 
 	public BoxNavigation navigate() throws QblStorageException {

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -309,7 +309,7 @@ class DirectoryMetadata {
 					"DELETE FROM files WHERE name=?");
 			st.setString(1, file.name);
 			if (st.executeUpdate() != 1) {
-				throw new QblStorageException("Failed to insert file");
+				throw new QblStorageException("Failed to delete file: Not found");
 			}
 
 		} catch (SQLException e) {

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -19,8 +19,6 @@ import java.util.UUID;
 
 class DirectoryMetadata {
 	private static final Logger logger = LoggerFactory.getLogger(DirectoryMetadata.class.getName());
-	//private static final String JDBC_CLASS_NAME = "org.sqlite.JDBC";
-	private static final String JDBC_CLASS_NAME = "org.sqldroid.SQLDroidDriver";
 	private static final String JDBC_PREFIX = "jdbc:sqlite:";
 	public static final int TYPE_NONE = -1;
 	private final Connection connection;
@@ -98,13 +96,10 @@ class DirectoryMetadata {
 		}
 		Connection connection;
 		try {
-			Class.forName(JDBC_CLASS_NAME);
 			connection = DriverManager.getConnection(JDBC_PREFIX + path.getAbsolutePath());
 			connection.setAutoCommit(true);
-		} catch (ClassNotFoundException e) {
-			throw new RuntimeException("Cannot load JDBC class!", e);
 		} catch (SQLException e) {
-			throw new RuntimeException("Cannot load in-memory database!", e);
+			throw new RuntimeException("Cannot open database!", e);
 		}
 		DirectoryMetadata dm = new DirectoryMetadata(connection, root, deviceId, path,
 				UUID.randomUUID().toString(), tempDir);
@@ -119,13 +114,10 @@ class DirectoryMetadata {
 	static DirectoryMetadata openDatabase(File path, byte[] deviceId, String fileName, File tempDir) throws QblStorageException {
 		Connection connection;
 		try {
-			Class.forName(JDBC_CLASS_NAME);
 			connection = DriverManager.getConnection(JDBC_PREFIX + path.getAbsolutePath());
 			connection.setAutoCommit(true);
-		} catch (ClassNotFoundException e) {
-			throw new RuntimeException("Cannot load JDBC class!", e);
 		} catch (SQLException e) {
-			throw new RuntimeException("Cannot load in-memory database!", e);
+			throw new RuntimeException("Cannot open database!", e);
 		}
 		return new DirectoryMetadata(connection, deviceId, path, fileName, tempDir);
 	}

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -1,0 +1,28 @@
+package de.qabel.core.storage;
+
+import java.util.List;
+
+class DirectoryMetadata {
+	static DirectoryMetadata newDatabase() {
+		return new DirectoryMetadata();
+	}
+
+	List<BoxFile> listFiles() {
+		return null;
+	}
+
+	List<BoxFolder> listFolders() {
+		return null;
+	}
+
+	List<BoxExternal> listExternals() {
+		return null;
+	}
+
+	byte[] getVersion() {
+		return new byte[] {1};
+	}
+
+	void commit() {
+	}
+}

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -1,28 +1,133 @@
 package de.qabel.core.storage;
 
+import de.qabel.core.exceptions.QblStorageException;
+import de.qabel.core.module.ModuleManager;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.*;
+import java.util.ArrayList;
 import java.util.List;
 
 class DirectoryMetadata {
-	static DirectoryMetadata newDatabase() {
-		return new DirectoryMetadata();
+	private final static Logger logger = LoggerFactory.getLogger(DirectoryMetadata.class.getName());
+	private final static String JDBC_CLASS_NAME = "org.sqlite.JDBC";
+	private final static String JDBC_PREFIX = "jdbc:sqlite:";
+	private Connection connection;
+
+	public DirectoryMetadata(Connection connection) {
+		this.connection = connection;
 	}
 
-	List<BoxFile> listFiles() {
-		return null;
+	static DirectoryMetadata newDatabase() {
+		Connection connection;
+		try {
+			Class.forName(JDBC_CLASS_NAME);
+			connection = DriverManager.getConnection(JDBC_PREFIX + ":memory:");
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Cannot load JDBC class!", e);
+		} catch (SQLException e) {
+			throw new RuntimeException("Cannot load in-memory database!", e);
+		}
+		DirectoryMetadata dm = new DirectoryMetadata(connection);
+		try {
+			dm.initDatabase();
+		} catch (SQLException e) {
+			throw new RuntimeException("Cannot init the database", e);
+		}
+		return dm;
+	}
+
+	private void initDatabase() throws SQLException {
+		try (Statement statement = connection.createStatement()) {
+			statement.executeUpdate(initSql);
+		}
+	}
+
+	List<BoxFile> listFiles() throws QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			try (ResultSet rs = statement.executeQuery(
+					"SELECT block, name, size, mtime, key FROM files")) {
+				List<BoxFile> files = new ArrayList<>();
+				while (rs.next()) {
+					files.add(new BoxFile(rs.getString(1),
+							rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5)));
+				}
+				return files;
+			}
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
 	}
 
 	List<BoxFolder> listFolders() {
-		return null;
+		return new ArrayList<>();
 	}
 
 	List<BoxExternal> listExternals() {
-		return null;
+		return new ArrayList<>();
 	}
 
 	byte[] getVersion() {
-		return new byte[] {1};
+		return new byte[]{1};
 	}
 
 	void commit() {
 	}
+
+
+	void insertFile(BoxFile file) throws QblStorageException {
+		try {
+			PreparedStatement st = connection.prepareStatement(
+					"INSERT INTO files (block, name, size, mtime, key) VALUES(?, ?, ?, ?, ?)");
+			st.setString(1, file.block);
+			st.setString(2, file.name);
+			st.setLong(3, file.size);
+			st.setLong(4, file.mtime);
+			st.setBytes(5, file.key);
+			if (st.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert file");
+			}
+
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+
+	private String initSql =
+					  "CREATE TABLE meta ("
+					+ " name VARCHAR(24) PRIMARY KEY,"
+					+ " value TEXT );"
+					+ "CREATE TABLE spec_version ("
+					+ " version INTEGER PRIMARY KEY );"
+					+ "CREATE TABLE version ("
+					+ " id INTEGER PRIMARY KEY,"
+					+ " version BLOB NOT NULL,"
+					+ " time LONG NOT NULL );"
+					+ "CREATE TABLE shares ("
+					+ " id INTEGER PRIMARY KEY,"
+					+ " ref VARCHAR(255)NOT NULL,"
+					+ " recipient BLOB NOT NULL,"
+					+ " type INTEGER NOT NULL );"
+					+ "CREATE TABLE files ("
+					+ " id INTEGER PRIMARY KEY,"
+					+ " block VARCHAR(255)NOT NULL,"
+					+ " name VARCHAR(255)NOT NULL,"
+					+ " size LONG NOT NULL,"
+					+ " mtime LONG NOT NULL,"
+					+ " key BLOB NOT NULL );"
+					+ "CREATE TABLE folders ("
+					+ " id INTEGER PRIMARY KEY,"
+					+ " ref VARCHAR(255)NOT NULL,"
+					+ " name VARCHAR(255)NOT NULL,"
+					+ " key BLOB NOT NULL );"
+					+ "CREATE TABLE externals ("
+					+ " id INTEGER PRIMARY KEY,"
+					+ " owner BLOB NOT NULL,"
+					+ " name VARCHAR(255)NOT NULL,"
+					+ " key BLOB NOT NULL,"
+					+ " url TEXT NOT NULL )";
 }
+

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -1,11 +1,18 @@
 package de.qabel.core.storage;
 
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.exceptions.QblStorageException;
 import de.qabel.core.module.ModuleManager;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.jcajce.provider.digest.SHA256;
+import org.joda.time.DateTimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,89 +22,11 @@ class DirectoryMetadata {
 	private final static String JDBC_CLASS_NAME = "org.sqlite.JDBC";
 	private final static String JDBC_PREFIX = "jdbc:sqlite:";
 	private Connection connection;
-
-	public DirectoryMetadata(Connection connection) {
-		this.connection = connection;
-	}
-
-	static DirectoryMetadata newDatabase() {
-		Connection connection;
-		try {
-			Class.forName(JDBC_CLASS_NAME);
-			connection = DriverManager.getConnection(JDBC_PREFIX + ":memory:");
-		} catch (ClassNotFoundException e) {
-			throw new RuntimeException("Cannot load JDBC class!", e);
-		} catch (SQLException e) {
-			throw new RuntimeException("Cannot load in-memory database!", e);
-		}
-		DirectoryMetadata dm = new DirectoryMetadata(connection);
-		try {
-			dm.initDatabase();
-		} catch (SQLException e) {
-			throw new RuntimeException("Cannot init the database", e);
-		}
-		return dm;
-	}
-
-	private void initDatabase() throws SQLException {
-		try (Statement statement = connection.createStatement()) {
-			statement.executeUpdate(initSql);
-		}
-	}
-
-	List<BoxFile> listFiles() throws QblStorageException {
-		try (Statement statement = connection.createStatement()) {
-			try (ResultSet rs = statement.executeQuery(
-					"SELECT block, name, size, mtime, key FROM files")) {
-				List<BoxFile> files = new ArrayList<>();
-				while (rs.next()) {
-					files.add(new BoxFile(rs.getString(1),
-							rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5)));
-				}
-				return files;
-			}
-		} catch (SQLException e) {
-			throw new QblStorageException(e);
-		}
-	}
-
-	List<BoxFolder> listFolders() {
-		return new ArrayList<>();
-	}
-
-	List<BoxExternal> listExternals() {
-		return new ArrayList<>();
-	}
-
-	byte[] getVersion() {
-		return new byte[]{1};
-	}
-
-	void commit() {
-	}
+	private byte[] deviceId;
 
 
-	void insertFile(BoxFile file) throws QblStorageException {
-		try {
-			PreparedStatement st = connection.prepareStatement(
-					"INSERT INTO files (block, name, size, mtime, key) VALUES(?, ?, ?, ?, ?)");
-			st.setString(1, file.block);
-			st.setString(2, file.name);
-			st.setLong(3, file.size);
-			st.setLong(4, file.mtime);
-			st.setBytes(5, file.key);
-			if (st.executeUpdate() != 1) {
-				throw new QblStorageException("Failed to insert file");
-			}
-
-		} catch (SQLException e) {
-			throw new QblStorageException(e);
-		}
-	}
-
-
-	private String initSql =
-					  "CREATE TABLE meta ("
+	private final String initSql =
+			"CREATE TABLE meta ("
 					+ " name VARCHAR(24) PRIMARY KEY,"
 					+ " value TEXT );"
 					+ "CREATE TABLE spec_version ("
@@ -129,5 +58,234 @@ class DirectoryMetadata {
 					+ " name VARCHAR(255)NOT NULL,"
 					+ " key BLOB NOT NULL,"
 					+ " url TEXT NOT NULL )";
+
+
+	public DirectoryMetadata(Connection connection, byte[] deviceId) {
+		this.connection = connection;
+		this.deviceId = deviceId;
+	}
+
+	static DirectoryMetadata newDatabase(byte[] deviceId) throws QblStorageException {
+		Connection connection;
+		try {
+			Class.forName(JDBC_CLASS_NAME);
+			connection = DriverManager.getConnection(JDBC_PREFIX + ":memory:");
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Cannot load JDBC class!", e);
+		} catch (SQLException e) {
+			throw new RuntimeException("Cannot load in-memory database!", e);
+		}
+		DirectoryMetadata dm = new DirectoryMetadata(connection, deviceId);
+		try {
+			dm.initDatabase();
+		} catch (SQLException e) {
+			throw new RuntimeException("Cannot init the database", e);
+		}
+		return dm;
+	}
+
+	private void initDatabase() throws SQLException, QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			statement.executeUpdate(initSql);
+		}
+		try (PreparedStatement statement = connection.prepareStatement(
+				"INSERT INTO version (version, time) VALUES (?, ?)")) {
+			statement.setBytes(1, initVersion());
+			statement.setLong(2, DateTimeUtils.currentTimeMillis());
+			statement.executeUpdate();
+		}
+	}
+
+	private byte[] initVersion() throws QblStorageException {
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new QblStorageException(e);
+		}
+		md.update(new byte[] {0, 0});
+		md.update(deviceId);
+		return md.digest();
+	}
+
+	byte[] getVersion() throws QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			try (ResultSet rs = statement.executeQuery(
+					"SELECT version FROM version ORDER BY id DESC LIMIT 1")) {
+				if (rs.next()) {
+					return rs.getBytes(1);
+				} else {
+					throw new QblStorageException("No version found!");
+				}
+			}
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	void commit() throws QblStorageException {
+		byte[] oldVersion = getVersion();
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new QblStorageException(e);
+		}
+		md.update(new byte[] {0, 1});
+		md.update(oldVersion);
+		md.update(deviceId);
+		try (PreparedStatement statement = connection.prepareStatement(
+				"INSERT INTO version (version, time) VALUES (?, ?)")) {
+			statement.setBytes(1, md.digest());
+			statement.setLong(2, DateTimeUtils.currentTimeMillis());
+			if (statement.executeUpdate() != 1) {
+				throw new QblStorageException("Could not update version!");
+			}
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+
+	List<BoxFile> listFiles() throws QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			try (ResultSet rs = statement.executeQuery(
+					"SELECT block, name, size, mtime, key FROM files")) {
+				List<BoxFile> files = new ArrayList<>();
+				while (rs.next()) {
+					files.add(new BoxFile(rs.getString(1),
+							rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5)));
+				}
+				return files;
+			}
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+
+	void insertFile(BoxFile file) throws QblStorageException {
+		try {
+			PreparedStatement st = connection.prepareStatement(
+					"INSERT INTO files (block, name, size, mtime, key) VALUES(?, ?, ?, ?, ?)");
+			st.setString(1, file.block);
+			st.setString(2, file.name);
+			st.setLong(3, file.size);
+			st.setLong(4, file.mtime);
+			st.setBytes(5, file.key);
+			if (st.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert file");
+			}
+
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	void deleteFile(BoxFile file) throws QblStorageException {
+		try {
+			PreparedStatement st = connection.prepareStatement(
+					"DELETE FROM files WHERE name=?");
+			st.setString(1, file.name);
+			if (st.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert file");
+			}
+
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+	public void insertFolder(BoxFolder folder) throws QblStorageException {
+		try {
+			PreparedStatement st = connection.prepareStatement(
+					"INSERT INTO folders (ref, name, key) VALUES(?, ?, ?)");
+			st.setString(1, folder.ref);
+			st.setString(2, folder.name);
+			st.setBytes(3, folder.key);
+			if (st.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert folder");
+			}
+
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	public void deleteFolder(BoxFolder folder) throws QblStorageException {
+		try {
+			PreparedStatement st = connection.prepareStatement(
+					"DELETE FROM folders WHERE name=?");
+			st.setString(1, folder.name);
+			if (st.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert folder");
+			}
+
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	List<BoxFolder> listFolders() throws QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			try (ResultSet rs = statement.executeQuery(
+					"SELECT ref, name, key FROM folders")) {
+				List<BoxFolder> folders = new ArrayList<>();
+				while (rs.next()) {
+					folders.add(new BoxFolder(rs.getString(1), rs.getString(2), rs.getBytes(3)));
+				}
+				return folders;
+			}
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	public void insertExternal(BoxExternal external) throws QblStorageException {
+		try {
+			PreparedStatement st = connection.prepareStatement(
+					"INSERT INTO externals (url, name, owner, key) VALUES(?, ?, ?, ?)");
+			st.setString(1, external.url);
+			st.setString(2, external.name);
+			st.setBytes(3, external.owner.getKey());
+			st.setBytes(4, external.key);
+			if (st.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert external");
+			}
+
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	public void deleteExternal(BoxExternal external) throws QblStorageException {
+		try {
+			PreparedStatement st = connection.prepareStatement(
+					"DELETE FROM externals WHERE name=?");
+			st.setString(1, external.name);
+			if (st.executeUpdate() != 1) {
+				throw new QblStorageException("Failed to insert external");
+			}
+
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	List<BoxExternal> listExternals() throws QblStorageException {
+		try (Statement statement = connection.createStatement()) {
+			try (ResultSet rs = statement.executeQuery(
+					"SELECT url, name, owner, key FROM externals")) {
+				List<BoxExternal> externals = new ArrayList<>();
+				while (rs.next()) {
+					externals.add(new BoxExternal(rs.getString(1), rs.getString(2),
+							new QblECPublicKey(rs.getBytes(3)), rs.getBytes(4)));
+				}
+				return externals;
+			}
+		} catch (SQLException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
 }
 

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -46,9 +46,8 @@ class DirectoryMetadata {
 					+ " recipient BLOB NOT NULL,"
 					+ " type INTEGER NOT NULL );"
 					+ "CREATE TABLE files ("
-					+ " id INTEGER PRIMARY KEY,"
 					+ " block VARCHAR(255)NOT NULL,"
-					+ " name VARCHAR(255)NOT NULL,"
+					+ " name VARCHAR(255)NOT NULL PRIMARY KEY,"
 					+ " size LONG NOT NULL,"
 					+ " mtime LONG NOT NULL,"
 					+ " key BLOB NOT NULL );"
@@ -408,7 +407,7 @@ class DirectoryMetadata {
 		}
 	}
 
-	public BoxFile getFile(String name) throws QblStorageException {
+	BoxFile getFile(String name) throws QblStorageException {
 		try (PreparedStatement statement = connection.prepareStatement(
 				"SELECT block, name, size, mtime, key FROM files WHERE name=?")) {
 			statement.setString(1, name);
@@ -417,7 +416,7 @@ class DirectoryMetadata {
 					return new BoxFile(rs.getString(1),
 							rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getBytes(5));
 				}
-				throw new QblStorageNotFound("File not found");
+				return null;
 			}
 		} catch (SQLException e) {
 			throw new QblStorageException(e);

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -93,6 +93,7 @@ class DirectoryMetadata {
 		try {
 			Class.forName(JDBC_CLASS_NAME);
 			connection = DriverManager.getConnection(JDBC_PREFIX + path.toAbsolutePath().toString());
+			connection.setAutoCommit(true);
 		} catch (ClassNotFoundException e) {
 			throw new RuntimeException("Cannot load JDBC class!", e);
 		} catch (SQLException e) {
@@ -113,6 +114,7 @@ class DirectoryMetadata {
 		try {
 			Class.forName(JDBC_CLASS_NAME);
 			connection = DriverManager.getConnection(JDBC_PREFIX + path.toAbsolutePath().toString());
+			connection.setAutoCommit(true);
 		} catch (ClassNotFoundException e) {
 			throw new RuntimeException("Cannot load JDBC class!", e);
 		} catch (SQLException e) {

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -298,6 +298,7 @@ class DirectoryMetadata {
 			}
 
 		} catch (SQLException e) {
+			logger.error("Could not insert file " + file.name);
 			throw new QblStorageException(e);
 		}
 	}

--- a/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/core/storage/DirectoryMetadata.java
@@ -275,7 +275,7 @@ class DirectoryMetadata {
 			throw new QblStorageException(e);
 		}
 	}
-	public void insertFolder(BoxFolder folder) throws QblStorageException {
+	void insertFolder(BoxFolder folder) throws QblStorageException {
 		try {
 			PreparedStatement st = connection.prepareStatement(
 					"INSERT INTO folders (ref, name, key) VALUES(?, ?, ?)");
@@ -291,7 +291,7 @@ class DirectoryMetadata {
 		}
 	}
 
-	public void deleteFolder(BoxFolder folder) throws QblStorageException {
+	void deleteFolder(BoxFolder folder) throws QblStorageException {
 		try {
 			PreparedStatement st = connection.prepareStatement(
 					"DELETE FROM folders WHERE name=?");
@@ -320,7 +320,7 @@ class DirectoryMetadata {
 		}
 	}
 
-	public void insertExternal(BoxExternal external) throws QblStorageException {
+	void insertExternal(BoxExternal external) throws QblStorageException {
 		try {
 			PreparedStatement st = connection.prepareStatement(
 					"INSERT INTO externals (url, name, owner, key) VALUES(?, ?, ?, ?)");
@@ -337,7 +337,7 @@ class DirectoryMetadata {
 		}
 	}
 
-	public void deleteExternal(BoxExternal external) throws QblStorageException {
+	void deleteExternal(BoxExternal external) throws QblStorageException {
 		try {
 			PreparedStatement st = connection.prepareStatement(
 					"DELETE FROM externals WHERE name=?");

--- a/src/main/java/de/qabel/core/storage/FolderNavigation.java
+++ b/src/main/java/de/qabel/core/storage/FolderNavigation.java
@@ -3,6 +3,8 @@ package de.qabel.core.storage;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
 import de.qabel.core.exceptions.QblStorageNotFound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -13,6 +15,9 @@ import java.nio.file.Path;
 import java.security.InvalidKeyException;
 
 public class FolderNavigation extends AbstractNavigation {
+
+	private static final Logger logger = LoggerFactory.getLogger(FolderNavigation.class.getName());
+
 	private final byte[] key;
 
 	FolderNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] key, byte[] deviceId,
@@ -23,12 +28,14 @@ public class FolderNavigation extends AbstractNavigation {
 
 	@Override
 	protected void uploadDirectoryMetadata() throws QblStorageException {
+		logger.info("Uploading directory metadata");
 		SecretKey secretKey = new SecretKeySpec(key, "AES");
 		uploadEncrypted(dm.getPath().toFile(), secretKey, dm.getFileName());
 	}
 
 	@Override
 	protected DirectoryMetadata reloadMetadata() throws QblStorageException {
+		logger.info("Reloading directory metadata");
 		// duplicate of navigate()
 		try {
 			InputStream indexDl = readBackend.download(dm.getFileName());

--- a/src/main/java/de/qabel/core/storage/FolderNavigation.java
+++ b/src/main/java/de/qabel/core/storage/FolderNavigation.java
@@ -1,0 +1,70 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.exceptions.QblStorageException;
+
+import java.io.InputStream;
+import java.util.List;
+
+public class FolderNavigation implements BoxNavigation {
+
+	DirectoryMetadata dm;
+	QblECKeyPair keyPair;
+	byte[] deviceId;
+
+	FolderNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] deviceId) {
+		this.dm = dm;
+		this.keyPair = keyPair;
+		this.deviceId = deviceId;
+	}
+
+	@Override
+	public BoxNavigation navigate(BoxFolder target) {
+		return null;
+	}
+
+	@Override
+	public BoxNavigation navigate(BoxExternal target) {
+		return null;
+	}
+
+	@Override
+	public List<BoxFile> listFiles() throws QblStorageException {
+		return dm.listFiles();
+	}
+
+	@Override
+	public List<BoxFolder> listFolder() throws QblStorageException {
+		return dm.listFolders();
+	}
+
+	@Override
+	public List<BoxExternal> listExternals() throws QblStorageException {
+		return dm.listExternals();
+	}
+
+	@Override
+	public BoxFile upload(String name, InputStream content) throws QblStorageException {
+		return null;
+	}
+
+	@Override
+	public InputStream download(BoxFile file) throws QblStorageException {
+		return null;
+	}
+
+	@Override
+	public void delete(BoxFile file) throws QblStorageException {
+
+	}
+
+	@Override
+	public void delete(BoxFolder folder) throws QblStorageException {
+
+	}
+
+	@Override
+	public void delete(BoxExternal external) throws QblStorageException {
+
+	}
+}

--- a/src/main/java/de/qabel/core/storage/FolderNavigation.java
+++ b/src/main/java/de/qabel/core/storage/FolderNavigation.java
@@ -8,10 +8,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.InvalidKeyException;
 
 public class FolderNavigation extends AbstractNavigation {
@@ -30,7 +29,7 @@ public class FolderNavigation extends AbstractNavigation {
 	protected void uploadDirectoryMetadata() throws QblStorageException {
 		logger.info("Uploading directory metadata");
 		SecretKey secretKey = new SecretKeySpec(key, "AES");
-		uploadEncrypted(dm.getPath().toFile(), secretKey, dm.getFileName());
+		uploadEncrypted(dm.getPath(), secretKey, dm.getFileName());
 	}
 
 	@Override
@@ -39,10 +38,10 @@ public class FolderNavigation extends AbstractNavigation {
 		// duplicate of navigate()
 		try {
 			InputStream indexDl = readBackend.download(dm.getFileName());
-			Path tmp = Files.createTempFile(null, null);
+			File tmp = File.createTempFile("dir", "db", dm.getTempDir());
 			SecretKey key = makeKey(this.key);
-			if (cryptoUtils.decryptFileAuthenticatedSymmetricAndValidateTag(indexDl, tmp.toFile(), key)) {
-				return DirectoryMetadata.openDatabase(tmp, deviceId, dm.getFileName());
+			if (cryptoUtils.decryptFileAuthenticatedSymmetricAndValidateTag(indexDl, tmp, key)) {
+				return DirectoryMetadata.openDatabase(tmp, deviceId, dm.getFileName(), dm.getTempDir());
 			} else {
 				throw new QblStorageNotFound("Invalid key");
 			}

--- a/src/main/java/de/qabel/core/storage/FolderNavigation.java
+++ b/src/main/java/de/qabel/core/storage/FolderNavigation.java
@@ -3,68 +3,22 @@ package de.qabel.core.storage;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
 
-import java.io.InputStream;
-import java.util.List;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
-public class FolderNavigation implements BoxNavigation {
+public class FolderNavigation extends AbstractNavigation {
+	private final byte[] key;
 
-	DirectoryMetadata dm;
-	QblECKeyPair keyPair;
-	byte[] deviceId;
-
-	FolderNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] deviceId) {
-		this.dm = dm;
-		this.keyPair = keyPair;
-		this.deviceId = deviceId;
+	FolderNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] key, byte[] deviceId,
+	                 StorageReadBackend readBackend, StorageWriteBackend writeBackend) {
+		super(dm, keyPair, deviceId, readBackend, writeBackend);
+		this.key = key;
 	}
 
 	@Override
-	public BoxNavigation navigate(BoxFolder target) {
-		return null;
-	}
-
-	@Override
-	public BoxNavigation navigate(BoxExternal target) {
-		return null;
-	}
-
-	@Override
-	public List<BoxFile> listFiles() throws QblStorageException {
-		return dm.listFiles();
-	}
-
-	@Override
-	public List<BoxFolder> listFolder() throws QblStorageException {
-		return dm.listFolders();
-	}
-
-	@Override
-	public List<BoxExternal> listExternals() throws QblStorageException {
-		return dm.listExternals();
-	}
-
-	@Override
-	public BoxFile upload(String name, InputStream content) throws QblStorageException {
-		return null;
-	}
-
-	@Override
-	public InputStream download(BoxFile file) throws QblStorageException {
-		return null;
-	}
-
-	@Override
-	public void delete(BoxFile file) throws QblStorageException {
-
-	}
-
-	@Override
-	public void delete(BoxFolder folder) throws QblStorageException {
-
-	}
-
-	@Override
-	public void delete(BoxExternal external) throws QblStorageException {
-
+	public void commit() throws QblStorageException {
+		dm.commit();
+		SecretKey secretKey = new SecretKeySpec(key, "AES");
+		uploadEncrypted(dm.getPath().toFile(), secretKey, dm.getFileName());
 	}
 }

--- a/src/main/java/de/qabel/core/storage/IndexNavigation.java
+++ b/src/main/java/de/qabel/core/storage/IndexNavigation.java
@@ -1,0 +1,29 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.exceptions.QblStorageException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.InvalidKeyException;
+
+public class IndexNavigation extends AbstractNavigation {
+
+	IndexNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] deviceId,
+	                StorageReadBackend readBackend, StorageWriteBackend writeBackend) {
+		super(dm, keyPair, deviceId, readBackend, writeBackend);
+	}
+
+	@Override
+	public void commit() throws QblStorageException {
+		dm.commit();
+		try {
+			byte[] plaintext = Files.readAllBytes(dm.path);
+			byte[] encrypted = cryptoUtils.createBox(keyPair, keyPair.getPub(), plaintext, 0);
+			writeBackend.upload(dm.getFileName(), new ByteArrayInputStream(encrypted));
+		} catch (IOException | InvalidKeyException e) {
+			throw new QblStorageException(e);
+		}
+	}
+}

--- a/src/main/java/de/qabel/core/storage/IndexNavigation.java
+++ b/src/main/java/de/qabel/core/storage/IndexNavigation.java
@@ -8,12 +8,7 @@ import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.*;
 import java.security.InvalidKeyException;
 
 public class IndexNavigation extends AbstractNavigation {
@@ -30,25 +25,25 @@ public class IndexNavigation extends AbstractNavigation {
 		// TODO: duplicate with BoxVoume.navigate()
 		String rootRef = dm.getFileName();
 		InputStream indexDl = readBackend.download(rootRef);
-		Path tmp;
+		File tmp;
 		try {
 			byte[] encrypted = IOUtils.toByteArray(indexDl);
 			DecryptedPlaintext plaintext = cryptoUtils.readBox(keyPair, encrypted);
-			tmp = Files.createTempFile(null, null);
+			tmp = File.createTempFile("dir", "db", dm.getTempDir());
 			logger.info("Using " + tmp.toString() + " for the metadata file");
-			OutputStream out = Files.newOutputStream(tmp);
+			OutputStream out = new FileOutputStream(tmp);
 			out.write(plaintext.getPlaintext());
 			out.close();
 		} catch (IOException | InvalidCipherTextException | InvalidKeyException e) {
 			throw new QblStorageException(e);
 		}
-		return DirectoryMetadata.openDatabase(tmp, deviceId, rootRef);
+		return DirectoryMetadata.openDatabase(tmp, deviceId, rootRef, dm.getTempDir());
 	}
 
 	@Override
 	protected void uploadDirectoryMetadata() throws QblStorageException {
 		try {
-			byte[] plaintext = Files.readAllBytes(dm.path);
+			byte[] plaintext = IOUtils.toByteArray(new FileInputStream(dm.path));
 			byte[] encrypted = cryptoUtils.createBox(keyPair, keyPair.getPub(), plaintext, 0);
 			writeBackend.upload(dm.getFileName(), new ByteArrayInputStream(encrypted));
 			logger.info("Uploading metadata file with name " + dm.getFileName());

--- a/src/main/java/de/qabel/core/storage/IndexNavigation.java
+++ b/src/main/java/de/qabel/core/storage/IndexNavigation.java
@@ -1,14 +1,24 @@
 package de.qabel.core.storage;
 
+import com.amazonaws.util.IOUtils;
+import de.qabel.core.crypto.DecryptedPlaintext;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.InvalidKeyException;
 
 public class IndexNavigation extends AbstractNavigation {
+
+	private static final Logger logger = LoggerFactory.getLogger(IndexNavigation.class.getName());
 
 	IndexNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] deviceId,
 	                StorageReadBackend readBackend, StorageWriteBackend writeBackend) {
@@ -16,12 +26,32 @@ public class IndexNavigation extends AbstractNavigation {
 	}
 
 	@Override
-	public void commit() throws QblStorageException {
-		dm.commit();
+	protected DirectoryMetadata reloadMetadata() throws QblStorageException {
+		// TODO: duplicate with BoxVoume.navigate()
+		String rootRef = dm.getFileName();
+		InputStream indexDl = readBackend.download(rootRef);
+		Path tmp;
+		try {
+			byte[] encrypted = IOUtils.toByteArray(indexDl);
+			DecryptedPlaintext plaintext = cryptoUtils.readBox(keyPair, encrypted);
+			tmp = Files.createTempFile(null, null);
+			logger.info("Using " + tmp.toString() + " for the metadata file");
+			OutputStream out = Files.newOutputStream(tmp);
+			out.write(plaintext.getPlaintext());
+			out.close();
+		} catch (IOException | InvalidCipherTextException | InvalidKeyException e) {
+			throw new QblStorageException(e);
+		}
+		return DirectoryMetadata.openDatabase(tmp, deviceId, rootRef);
+	}
+
+	@Override
+	protected void uploadDirectoryMetadata() throws QblStorageException {
 		try {
 			byte[] plaintext = Files.readAllBytes(dm.path);
 			byte[] encrypted = cryptoUtils.createBox(keyPair, keyPair.getPub(), plaintext, 0);
 			writeBackend.upload(dm.getFileName(), new ByteArrayInputStream(encrypted));
+			logger.info("Uploading metadata file with name " + dm.getFileName());
 		} catch (IOException | InvalidKeyException e) {
 			throw new QblStorageException(e);
 		}

--- a/src/main/java/de/qabel/core/storage/IndexNavigation.java
+++ b/src/main/java/de/qabel/core/storage/IndexNavigation.java
@@ -4,7 +4,7 @@ import com.amazonaws.util.IOUtils;
 import de.qabel.core.crypto.DecryptedPlaintext;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
-import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.spongycastle.crypto.InvalidCipherTextException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/de/qabel/core/storage/S3ReadBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3ReadBackend.java
@@ -53,9 +53,10 @@ class S3ReadBackend extends StorageReadBackend {
 			throw new QblStorageException(e);
 		}
 		int status = response.getStatusLine().getStatusCode();
-		if (status == 404 || status == 403) {
+		if ((status == 404) || (status == 403)) {
 			throw new QblStorageNotFound("File not found");
-		} else if (status != 200) {
+		}
+		if (status != 200) {
 			throw new QblStorageException("Download error");
 		}
 		HttpEntity entity = response.getEntity();

--- a/src/main/java/de/qabel/core/storage/S3ReadBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3ReadBackend.java
@@ -2,9 +2,7 @@ package de.qabel.core.storage;
 
 import de.qabel.core.exceptions.QblStorageException;
 import de.qabel.core.exceptions.QblStorageNotFound;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -13,7 +11,6 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;

--- a/src/main/java/de/qabel/core/storage/S3ReadBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3ReadBackend.java
@@ -1,6 +1,7 @@
 package de.qabel.core.storage;
 
 import de.qabel.core.exceptions.QblStorageException;
+import de.qabel.core.exceptions.QblStorageNotFound;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -40,8 +41,11 @@ class S3ReadBackend extends StorageReadBackend {
 		} catch (IOException e) {
 			throw new QblStorageException(e);
 		}
-		if (response.getStatusLine().getStatusCode() != 200) {
-			throw new QblStorageException("Not successful");
+		int status = response.getStatusLine().getStatusCode();
+		if (status == 404 || status == 403) {
+			throw new QblStorageNotFound("File not found");
+		} else if (status != 200) {
+			throw new QblStorageException("Download error");
 		}
 		HttpEntity entity = response.getEntity();
 		if (entity == null) {

--- a/src/main/java/de/qabel/core/storage/S3ReadBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3ReadBackend.java
@@ -10,6 +10,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -18,6 +20,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 class S3ReadBackend extends StorageReadBackend {
+
+	private static final Logger logger = LoggerFactory.getLogger(S3ReadBackend.class.getName());
 
 	String root;
 	private final CloseableHttpClient httpclient;
@@ -36,9 +40,12 @@ class S3ReadBackend extends StorageReadBackend {
 
 		httpclient = HttpClients.custom()
 				.setConnectionManager(connManager).build();
+
+		logger.info("S3ReadBackend with root address set to " + root);
 	}
 
 	InputStream download(String name) throws QblStorageException {
+		logger.info("Downloading " + name);
 		URI uri;
 		try {
 			uri = new URI(this.root + '/' + name);

--- a/src/main/java/de/qabel/core/storage/S3ReadBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3ReadBackend.java
@@ -1,0 +1,57 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.exceptions.QblStorageException;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+class S3ReadBackend extends StorageReadBackend {
+
+	String root;
+	private CloseableHttpClient httpclient;
+
+	S3ReadBackend(String bucket, String prefix) {
+		 this("https://"+bucket+".s3.amazonaws.com/"+prefix);
+	}
+
+	S3ReadBackend(String root) {
+		this.root = root;
+		httpclient = HttpClients.createMinimal();
+	}
+
+	InputStream download(String name) throws QblStorageException {
+		URI uri;
+		try {
+			uri = new URI(this.root + '/' + name);
+		} catch (URISyntaxException e) {
+			throw new QblStorageException(e);
+		}
+		HttpGet httpGet = new HttpGet(uri);
+		HttpResponse response;
+		try {
+			response = httpclient.execute(httpGet);
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		}
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new QblStorageException("Not successful");
+		}
+		HttpEntity entity = response.getEntity();
+		if (entity == null) {
+			throw new QblStorageException("No content");
+		}
+		try {
+			InputStream content = entity.getContent();
+			return content;
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		}
+	}
+}

--- a/src/main/java/de/qabel/core/storage/S3WriteBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3WriteBackend.java
@@ -9,9 +9,9 @@ import java.io.InputStream;
 
 class S3WriteBackend extends StorageWriteBackend {
 
-	private final AmazonS3Client s3Client;
-	private final String bucket;
-	private final String prefix;
+	final AmazonS3Client s3Client;
+	final String bucket;
+	final String prefix;
 
 	S3WriteBackend(AWSCredentials credentials, String bucket, String prefix) {
 		s3Client = new AmazonS3Client(credentials);
@@ -37,4 +37,5 @@ class S3WriteBackend extends StorageWriteBackend {
 			throw new QblStorageException(e);
 		}
 	}
+
 }

--- a/src/main/java/de/qabel/core/storage/S3WriteBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3WriteBackend.java
@@ -5,10 +5,14 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import de.qabel.core.exceptions.QblStorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 
 class S3WriteBackend extends StorageWriteBackend {
+
+	private static final Logger logger = LoggerFactory.getLogger(FolderNavigation.class.getName());
 
 	final AmazonS3Client s3Client;
 	final String bucket;
@@ -18,11 +22,12 @@ class S3WriteBackend extends StorageWriteBackend {
 		s3Client = new AmazonS3Client(credentials);
 		this.bucket = bucket;
 		this.prefix = prefix;
-
+		logger.info("S3WriteBackend running on prefix " + prefix);
 	}
 
 	@Override
 	long upload(String name, InputStream inputStream) throws QblStorageException {
+		logger.info("Uploading to name " + name);
 		try {
 			String path = prefix + '/' + name;
 			s3Client.putObject(bucket, path, inputStream, new ObjectMetadata());
@@ -35,6 +40,7 @@ class S3WriteBackend extends StorageWriteBackend {
 
 	@Override
 	void delete(String name) throws QblStorageException {
+		logger.info("Deleting name " + name);
 		try {
 			s3Client.deleteObject(bucket, prefix + '/' + name);
 		} catch (RuntimeException e) {

--- a/src/main/java/de/qabel/core/storage/S3WriteBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3WriteBackend.java
@@ -3,6 +3,7 @@ package de.qabel.core.storage;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectResult;
 import de.qabel.core.exceptions.QblStorageException;
 
 import java.io.InputStream;
@@ -21,9 +22,12 @@ class S3WriteBackend extends StorageWriteBackend {
 	}
 
 	@Override
-	void upload(String name, InputStream inputStream) throws QblStorageException {
+	long upload(String name, InputStream inputStream) throws QblStorageException {
 		try {
-			s3Client.putObject(bucket, prefix + '/' + name, inputStream, new ObjectMetadata());
+			String path = prefix + '/' + name;
+			s3Client.putObject(bucket, path, inputStream, new ObjectMetadata());
+			ObjectMetadata objectMetadata = s3Client.getObjectMetadata(bucket, path);
+			return objectMetadata.getLastModified().getTime();
 		} catch (RuntimeException e) {
 			throw new QblStorageException(e);
 		}

--- a/src/main/java/de/qabel/core/storage/S3WriteBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3WriteBackend.java
@@ -1,0 +1,32 @@
+package de.qabel.core.storage;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import de.qabel.core.exceptions.QblStorageException;
+
+import java.io.InputStream;
+
+class S3WriteBackend extends StorageWriteBackend {
+
+	private final AmazonS3Client s3Client;
+	private final String bucket;
+	private final String prefix;
+
+	S3WriteBackend(AWSCredentials credentials, String bucket, String prefix) {
+		s3Client = new AmazonS3Client(credentials);
+		this.bucket = bucket;
+		this.prefix = prefix;
+
+	}
+
+	@Override
+	void upload(String name, InputStream inputStream) throws QblStorageException {
+		s3Client.putObject(bucket, prefix + '/' + name, inputStream, new ObjectMetadata());
+	}
+
+	@Override
+	void delete(String name) throws QblStorageException {
+		s3Client.deleteObject(bucket, prefix + '/' + name);
+	}
+}

--- a/src/main/java/de/qabel/core/storage/S3WriteBackend.java
+++ b/src/main/java/de/qabel/core/storage/S3WriteBackend.java
@@ -22,11 +22,19 @@ class S3WriteBackend extends StorageWriteBackend {
 
 	@Override
 	void upload(String name, InputStream inputStream) throws QblStorageException {
-		s3Client.putObject(bucket, prefix + '/' + name, inputStream, new ObjectMetadata());
+		try {
+			s3Client.putObject(bucket, prefix + '/' + name, inputStream, new ObjectMetadata());
+		} catch (RuntimeException e) {
+			throw new QblStorageException(e);
+		}
 	}
 
 	@Override
 	void delete(String name) throws QblStorageException {
-		s3Client.deleteObject(bucket, prefix + '/' + name);
+		try {
+			s3Client.deleteObject(bucket, prefix + '/' + name);
+		} catch (RuntimeException e) {
+			throw new QblStorageException(e);
+		}
 	}
 }

--- a/src/main/java/de/qabel/core/storage/StorageBlob.java
+++ b/src/main/java/de/qabel/core/storage/StorageBlob.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
-import org.bouncycastle.util.encoders.DecoderException;
-import org.bouncycastle.util.encoders.UrlBase64;
+import org.spongycastle.util.encoders.DecoderException;
+import org.spongycastle.util.encoders.UrlBase64;
 
 import de.qabel.core.exceptions.QblStorageInvalidBlobName;
 

--- a/src/main/java/de/qabel/core/storage/StorageReadBackend.java
+++ b/src/main/java/de/qabel/core/storage/StorageReadBackend.java
@@ -1,0 +1,10 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.exceptions.QblStorageException;
+
+import java.io.InputStream;
+
+abstract class StorageReadBackend {
+
+	abstract InputStream download(String name) throws QblStorageException;
+}

--- a/src/main/java/de/qabel/core/storage/StorageWriteBackend.java
+++ b/src/main/java/de/qabel/core/storage/StorageWriteBackend.java
@@ -1,0 +1,10 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.exceptions.QblStorageException;
+
+import java.io.InputStream;
+
+abstract class StorageWriteBackend {
+	abstract void upload(String name, InputStream inputStream) throws QblStorageException;
+	abstract void delete(String name) throws QblStorageException;
+}

--- a/src/main/java/de/qabel/core/storage/StorageWriteBackend.java
+++ b/src/main/java/de/qabel/core/storage/StorageWriteBackend.java
@@ -5,6 +5,6 @@ import de.qabel.core.exceptions.QblStorageException;
 import java.io.InputStream;
 
 abstract class StorageWriteBackend {
-	abstract void upload(String name, InputStream inputStream) throws QblStorageException;
+	abstract long upload(String name, InputStream content) throws QblStorageException;
 	abstract void delete(String name) throws QblStorageException;
 }

--- a/src/resources/config/log4j2.xml
+++ b/src/resources/config/log4j2.xml
@@ -12,7 +12,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="all" includeLocation="false">
+    <Root level="info" includeLocation="false">
       <AppenderRef ref="RandomAccessFile"/>
       <AppenderRef ref="Console"/>
     </Root>

--- a/src/test/java/de/qabel/core/crypto/CryptoUtilsTest.java
+++ b/src/test/java/de/qabel/core/crypto/CryptoUtilsTest.java
@@ -11,8 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.util.encoders.Hex;
+import org.spongycastle.crypto.InvalidCipherTextException;
+import org.spongycastle.util.encoders.Hex;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
@@ -1,6 +1,5 @@
 package de.qabel.core.storage;
 
-import de.qabel.core.crypto.QblECKeyPair;
 import org.apache.commons.io.FileUtils;
 
 import java.io.IOException;
@@ -17,7 +16,10 @@ public class BoxVolumeLocalTest extends BoxVolumeTest {
 
 		volume = new BoxVolume(new LocalReadBackend(tempFolder),
 				new LocalWriteBackend(tempFolder),
-				new QblECKeyPair(), deviceID);
+				keyPair, deviceID);
+		volume2 = new BoxVolume(new LocalReadBackend(tempFolder),
+				new LocalWriteBackend(tempFolder),
+				keyPair, deviceID2);
 	}
 
 	@Override

--- a/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
@@ -2,6 +2,7 @@ package de.qabel.core.storage;
 
 import org.apache.commons.io.FileUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,10 +17,10 @@ public class BoxVolumeLocalTest extends BoxVolumeTest {
 
 		volume = new BoxVolume(new LocalReadBackend(tempFolder),
 				new LocalWriteBackend(tempFolder),
-				keyPair, deviceID);
+				keyPair, deviceID, new File(System.getProperty("java.io.tmpdir")));
 		volume2 = new BoxVolume(new LocalReadBackend(tempFolder),
 				new LocalWriteBackend(tempFolder),
-				keyPair, deviceID2);
+				keyPair, deviceID2, new File(System.getProperty("java.io.tmpdir")));
 	}
 
 	@Override

--- a/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
@@ -2,7 +2,6 @@ package de.qabel.core.storage;
 
 import de.qabel.core.crypto.QblECKeyPair;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeLocalTest.java
@@ -1,0 +1,28 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.crypto.QblECKeyPair;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class BoxVolumeLocalTest extends BoxVolumeTest {
+
+	private Path tempFolder;
+
+	@Override
+	public void setUpVolume() throws IOException {
+		tempFolder = Files.createTempDirectory("");
+
+		volume = new BoxVolume(new LocalReadBackend(tempFolder),
+				new LocalWriteBackend(tempFolder),
+				new QblECKeyPair(), deviceID);
+	}
+
+	@Override
+	protected void cleanVolume() throws IOException {
+		FileUtils.deleteDirectory(tempFolder.toFile());
+	}
+}

--- a/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
@@ -17,8 +17,11 @@ public class BoxVolumeS3Test extends BoxVolumeTest {
 	void setUpVolume() {
 		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
 
-		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair(), deviceID,
+		QblECKeyPair keyPair = new QblECKeyPair();
+		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), keyPair, deviceID,
 			new File(System.getProperty("java.io.tmpdir")));
+		volume2 = new BoxVolume(bucket,prefix, chain.getCredentials(), keyPair, deviceID2,
+				new File(System.getProperty("java.io.tmpdir")));
 
 	}
 

--- a/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import de.qabel.core.crypto.QblECKeyPair;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +15,8 @@ public class BoxVolumeS3Test extends BoxVolumeTest {
 	void setUpVolume() {
 		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
 
-		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair(), deviceID);
+		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), keyPair, deviceID);
+		volume2 = new BoxVolume(bucket,prefix, chain.getCredentials(), keyPair, deviceID2);
 
 	}
 

--- a/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
@@ -1,0 +1,38 @@
+package de.qabel.core.storage;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import de.qabel.core.crypto.QblECKeyPair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BoxVolumeS3Test extends BoxVolumeTest {
+	@Override
+	void setUpVolume() {
+		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
+
+		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair(), deviceID);
+
+	}
+
+	@Override
+	protected void cleanVolume() {
+		AmazonS3Client client = ((S3WriteBackend) volume.writeBackend).s3Client;
+		ObjectListing listing = client.listObjects(bucket, prefix);
+		List<KeyVersion> keys = new ArrayList<>();
+		for (S3ObjectSummary summary : listing.getObjectSummaries()) {
+			keys.add(new KeyVersion(summary.getKey()));
+		}
+		if (keys.isEmpty()) {
+			return;
+		}
+		DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
+		deleteObjectsRequest.setKeys(keys);
+		client.deleteObjects(deleteObjectsRequest);
+	}
+}

--- a/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeS3Test.java
@@ -6,7 +6,9 @@ import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import de.qabel.core.crypto.QblECKeyPair;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,8 +17,8 @@ public class BoxVolumeS3Test extends BoxVolumeTest {
 	void setUpVolume() {
 		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
 
-		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), keyPair, deviceID);
-		volume2 = new BoxVolume(bucket,prefix, chain.getCredentials(), keyPair, deviceID2);
+		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair(), deviceID,
+			new File(System.getProperty("java.io.tmpdir")));
 
 	}
 

--- a/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
@@ -1,6 +1,8 @@
 package de.qabel.core.storage;
 
+
 import com.amazonaws.util.IOUtils;
+import de.qabel.core.crypto.CryptoUtils;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
 import de.qabel.core.exceptions.QblStorageNameConflict;
@@ -39,17 +41,9 @@ public abstract class BoxVolumeTest {
 
 	@Before
 	public void setUp() throws IOException, QblStorageException {
-		UUID uuid = UUID.randomUUID();
-		ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
-		bb.putLong(uuid.getMostSignificantBits());
-		bb.putLong(uuid.getLeastSignificantBits());
-		deviceID = bb.array();
-
-		UUID uuid2 = UUID.randomUUID();
-		ByteBuffer bb2 = ByteBuffer.wrap(new byte[16]);
-		bb2.putLong(uuid2.getMostSignificantBits());
-		bb2.putLong(uuid2.getLeastSignificantBits());
-		deviceID2 = bb2.array();
+		CryptoUtils utils = new CryptoUtils();
+		deviceID = utils.getRandomBytes(16);
+		deviceID2 = utils.getRandomBytes(16);
 
 		keyPair = new QblECKeyPair();
 

--- a/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
@@ -144,4 +144,14 @@ public abstract class BoxVolumeTest {
 		} catch (QblStorageNotFound e) { }
 	}
 
+	@Test
+	public void testOverrideFile() throws QblStorageException, IOException {
+		BoxNavigation nav = volume.navigate();
+		uploadFile(nav);
+		nav.commit();
+		uploadFile(nav);
+		nav.commit();
+		assertThat(nav.listFiles().size(), is(1));
+	}
+
 }

--- a/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
@@ -1,16 +1,25 @@
 package de.qabel.core.storage;
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.exceptions.QblStorageException;
+import de.qabel.core.exceptions.QblStorageNotFound;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -20,45 +29,60 @@ public class BoxVolumeTest {
 	private final static Logger logger = LoggerFactory.getLogger(BoxVolumeTest.class.getName());
 
 	BoxVolume volume;
+	private byte[] deviceID;
+	private String bucket = "qabel";
+	String prefix = UUID.randomUUID().toString();
+	private BoxVolume localVolume;
 
-
-	private void s3Init() {
-		String bucket = "qabel";
-		String prefix = UUID.randomUUID().toString();
+	@Before
+	public void setUp() throws IOException {
+		UUID uuid = UUID.randomUUID();
+		ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+		bb.putLong(uuid.getMostSignificantBits());
+		bb.putLong(uuid.getLeastSignificantBits());
+		deviceID = bb.array();
 
 		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
 
-		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair());
-	}
+		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair(), deviceID);
 
-	@Test
-	public void testS3Init() {
-		s3Init();
-	}
-
-	private void localInit() throws IOException {
 		Path tempFolder = Files.createTempDirectory("");
 
-		volume = new BoxVolume(new LocalReadBackend(tempFolder),
-			new LocalWriteBackend(tempFolder),
-			new QblECKeyPair());
+		localVolume = new BoxVolume(new LocalReadBackend(tempFolder),
+				new LocalWriteBackend(tempFolder),
+				new QblECKeyPair(), deviceID);
 	}
 
-	@Test
-	public void testLocalInit() throws IOException {
-		localInit();
+	@After
+	public void cleanUp() {
+		AmazonS3Client client = ((S3WriteBackend) volume.writeBackend).s3Client;
+		ObjectListing listing = client.listObjects(bucket, prefix);
+		List<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
+		for (S3ObjectSummary summary: listing.getObjectSummaries()) {
+			keys.add(new DeleteObjectsRequest.KeyVersion(summary.getKey()));
+		}
+		DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
+		deleteObjectsRequest.setKeys(keys);
+		client.deleteObjects(deleteObjectsRequest);
 	}
+
 
 	@Test
 	public void testShareManagement() {
 		fail("Not implemented");
 	}
 
-	@Test
-	public void testFindRootRef() throws QblStorageException {
-		s3Init();
+	@Test(expected = QblStorageNotFound.class)
+	public void testIndexNotFound() throws QblStorageException {
 		String root = volume.getRootRef();
 		assertThat(UUID.fromString(root), isA(UUID.class));
+		BoxNavigation nav = volume.navigate();
+	}
+
+	@Test
+	public void testCreateIndex() throws QblStorageException {
+		volume.createIndex(bucket, prefix);
+		BoxNavigation nav = volume.navigate();
 	}
 
 }

--- a/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
@@ -34,7 +34,7 @@ public abstract class BoxVolumeTest {
 	private final String testFileName = "src/test/java/de/qabel/core/crypto/testFile";
 
 	@Before
-	public void setUp() throws IOException {
+	public void setUp() throws IOException, QblStorageException {
 		UUID uuid = UUID.randomUUID();
 		ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
 		bb.putLong(uuid.getMostSignificantBits());
@@ -42,6 +42,8 @@ public abstract class BoxVolumeTest {
 		deviceID = bb.array();
 
 		setUpVolume();
+
+		volume.createIndex(bucket, prefix);
 	}
 
 	abstract void setUpVolume() throws IOException;
@@ -53,29 +55,19 @@ public abstract class BoxVolumeTest {
 
 	protected abstract void cleanVolume() throws IOException;
 
-	@Test(expected = QblStorageNotFound.class)
-	public void testIndexNotFound() throws QblStorageException {
-		String root = volume.getRootRef();
-		assertThat(UUID.fromString(root), isA(UUID.class));
-		volume.navigate();
-	}
-
 	@Test
 	public void testCreateIndex() throws QblStorageException {
-		volume.createIndex(bucket, prefix);
 		BoxNavigation nav = volume.navigate();
 		assertThat(nav.listFiles().size(), is(0));
 	}
 
 	@Test
 	public void testUploadFile() throws QblStorageException, IOException {
-		volume.createIndex(bucket, prefix);
 		uploadFile(volume.navigate());
 	}
 
 	@Test(expected = QblStorageNotFound.class)
 	public void testDeleteFile() throws QblStorageException, IOException {
-		volume.createIndex(bucket, prefix);
 		BoxNavigation nav = volume.navigate();
 		BoxFile boxFile = uploadFile(nav);
 		nav.delete(boxFile);
@@ -102,7 +94,6 @@ public abstract class BoxVolumeTest {
 
 	@Test
 	public void testCreateFolder() throws QblStorageException, IOException {
-		volume.createIndex(bucket, prefix);
 		BoxNavigation nav = volume.navigate();
 		BoxFolder boxFolder = nav.createFolder("foobdir");
 		nav.commit();
@@ -122,7 +113,6 @@ public abstract class BoxVolumeTest {
 
 	@Test
 	public void testDeleteFolder() throws QblStorageException, IOException {
-		volume.createIndex(bucket, prefix);
 		BoxNavigation nav = volume.navigate();
 		BoxFolder boxFolder = nav.createFolder("foobdir");
 		nav.commit();

--- a/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
@@ -2,7 +2,11 @@ package de.qabel.core.storage;
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.exceptions.QblStorageException;
+import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,30 +17,48 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 public class BoxVolumeTest {
+	private final static Logger logger = LoggerFactory.getLogger(BoxVolumeTest.class.getName());
 
 	BoxVolume volume;
 
-	@Test
-	public void testS3Init() {
+
+	private void s3Init() {
 		String bucket = "qabel";
 		String prefix = UUID.randomUUID().toString();
 
 		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
 
 		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair());
-
-		assertThat(volume.cache.size(), is(0));
 	}
 
 	@Test
-	public void testLocalInit() throws IOException {
+	public void testS3Init() {
+		s3Init();
+	}
+
+	private void localInit() throws IOException {
 		Path tempFolder = Files.createTempDirectory("");
 
 		volume = new BoxVolume(new LocalReadBackend(tempFolder),
 			new LocalWriteBackend(tempFolder),
 			new QblECKeyPair());
+	}
 
-		assertThat(volume.cache.size(), is(0));
+	@Test
+	public void testLocalInit() throws IOException {
+		localInit();
+	}
+
+	@Test
+	public void testShareManagement() {
+		fail("Not implemented");
+	}
+
+	@Test
+	public void testFindRootRef() throws QblStorageException {
+		s3Init();
+		String root = volume.getRootRef();
+		assertThat(UUID.fromString(root), isA(UUID.class));
 	}
 
 }

--- a/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
@@ -1,0 +1,42 @@
+package de.qabel.core.storage;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import de.qabel.core.crypto.QblECKeyPair;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class BoxVolumeTest {
+
+	BoxVolume volume;
+
+	@Test
+	public void testS3Init() {
+		String bucket = "qabel";
+		String prefix = UUID.randomUUID().toString();
+
+		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
+
+		volume = new BoxVolume(bucket,prefix, chain.getCredentials(), new QblECKeyPair());
+
+		assertThat(volume.cache.size(), is(0));
+	}
+
+	@Test
+	public void testLocalInit() throws IOException {
+		Path tempFolder = Files.createTempDirectory("");
+
+		volume = new BoxVolume(new LocalReadBackend(tempFolder),
+			new LocalWriteBackend(tempFolder),
+			new QblECKeyPair());
+
+		assertThat(volume.cache.size(), is(0));
+	}
+
+}

--- a/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/core/storage/BoxVolumeTest.java
@@ -69,50 +69,50 @@ public abstract class BoxVolumeTest {
 
 	@Test
 	public void testUploadFile() throws QblStorageException, IOException {
-		uploadFileToIndex();
+		volume.createIndex(bucket, prefix);
+		uploadFile(volume.navigate());
 	}
 
 	@Test(expected = QblStorageNotFound.class)
 	public void testDeleteFile() throws QblStorageException, IOException {
-		BoxNavigation nav = uploadFileToIndex();
-		BoxFile boxFile = nav.listFiles().get(0);
+		volume.createIndex(bucket, prefix);
+		BoxNavigation nav = volume.navigate();
+		BoxFile boxFile = uploadFile(nav);
 		nav.delete(boxFile);
 		nav.commit();
 		nav.download(boxFile);
 	}
 
-	private BoxNavigation uploadFileToIndex() throws QblStorageException, IOException {
-		volume.createIndex(bucket, prefix);
-		BoxNavigation nav = volume.navigate();
+	private BoxFile uploadFile(BoxNavigation nav) throws QblStorageException, IOException {
 		File file = new File(testFileName);
-		nav.upload("foobar", file);
+		BoxFile boxFile = nav.upload("foobar", file);
 		nav.commit();
 		BoxNavigation nav_new = volume.navigate();
-		InputStream dlStream = nav_new.download(nav_new.listFiles().get(0));
+		checkFile(boxFile, nav_new);
+		return boxFile;
+	}
+
+	private void checkFile(BoxFile boxFile, BoxNavigation nav_new) throws QblStorageException, IOException {
+		InputStream dlStream = nav_new.download(boxFile);
 		assertNotNull("Download stream is null", dlStream);
 		byte[] dl = IOUtils.toByteArray(dlStream);
+		File file = new File(testFileName);
 		assertThat(dl, is(Files.readAllBytes(file.toPath())));
-		return nav_new;
 	}
 
 	@Test
 	public void testCreateFolder() throws QblStorageException, IOException {
 		volume.createIndex(bucket, prefix);
 		BoxNavigation nav = volume.navigate();
-		File file = new File(testFileName);
 		BoxFolder boxFolder = nav.createFolder("foobdir");
 		nav.commit();
 
 		BoxNavigation folder = nav.navigate(boxFolder);
 		assertNotNull(folder);
-		folder.upload("foobar", file);
-		folder.commit();
+		BoxFile boxFile = uploadFile(folder);
 
 		BoxNavigation folder_new = nav.navigate(boxFolder);
-		InputStream dlStream = folder_new.download(folder_new.listFiles().get(0));
-		assertNotNull("Download stream is null", dlStream);
-		byte[] dl = IOUtils.toByteArray(dlStream);
-		assertThat(dl, is(Files.readAllBytes(file.toPath())));
+		checkFile(boxFile, folder_new);
 
 		BoxNavigation nav_new = volume.navigate();
 		List<BoxFolder> folders = nav_new.listFolders();
@@ -124,27 +124,13 @@ public abstract class BoxVolumeTest {
 	public void testDeleteFolder() throws QblStorageException, IOException {
 		volume.createIndex(bucket, prefix);
 		BoxNavigation nav = volume.navigate();
-		File file = new File(testFileName);
 		BoxFolder boxFolder = nav.createFolder("foobdir");
 		nav.commit();
 
 		BoxNavigation folder = nav.navigate(boxFolder);
-		assertNotNull(folder);
-		folder.upload("foobar", file);
+		BoxFile boxFile = uploadFile(folder);
 		BoxFolder subfolder = folder.createFolder("subfolder");
 		folder.commit();
-
-		BoxNavigation folder_new = nav.navigate(boxFolder);
-		BoxFile boxFile = folder_new.listFiles().get(0);
-		InputStream dlStream = folder_new.download(boxFile);
-		assertNotNull("Download stream is null", dlStream);
-		byte[] dl = IOUtils.toByteArray(dlStream);
-		assertThat(dl, is(Files.readAllBytes(file.toPath())));
-
-		BoxNavigation nav_new = volume.navigate();
-		List<BoxFolder> folders = nav_new.listFolders();
-		assertThat(folders.size(), is(1));
-		assertThat(boxFolder, equalTo(folders.get(0)));
 
 		nav.delete(boxFolder);
 		nav.commit();
@@ -153,17 +139,17 @@ public abstract class BoxVolumeTest {
 		checkDeleted(boxFolder, subfolder, boxFile, nav_after);
 	}
 
-	private void checkDeleted(BoxFolder boxFolder, BoxFolder subfolder, BoxFile boxFile, BoxNavigation nav_after) throws QblStorageException {
+	private void checkDeleted(BoxFolder boxFolder, BoxFolder subfolder, BoxFile boxFile, BoxNavigation nav) throws QblStorageException {
 		try {
-			nav_after.download(boxFile);
+			nav.download(boxFile);
 			fail("Could download file in deleted folder");
 		} catch (QblStorageNotFound e) { }
 		try {
-			nav_after.navigate(boxFolder);
+			nav.navigate(boxFolder);
 			fail("Could navigate to deleted folder");
 		} catch (QblStorageNotFound e) { }
 		try {
-			nav_after.navigate(subfolder);
+			nav.navigate(subfolder);
 			fail("Could navigate to deleted subfolder");
 		} catch (QblStorageNotFound e) { }
 	}

--- a/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
+++ b/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
@@ -1,10 +1,13 @@
 package de.qabel.core.storage;
 
+import de.qabel.core.crypto.CryptoUtils;
 import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.exceptions.QblStorageException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.UUID;
@@ -24,7 +27,8 @@ public class DirectoryMetadataTest {
 		bb.putLong(uuid.getMostSignificantBits());
 		bb.putLong(uuid.getLeastSignificantBits());
 
-		dm = DirectoryMetadata.newDatabase("https://localhost", bb.array());
+		dm = DirectoryMetadata.newDatabase("https://localhost", bb.array(),
+			new File(System.getProperty("java.io.tmpdir")));
 	}
 
 	@Test
@@ -40,12 +44,13 @@ public class DirectoryMetadataTest {
 
 	@Test
 	public void testFileOperations() throws QblStorageException {
-		BoxFile file = new BoxFile("block", "name", 0l, 0l, new byte[] {1,2,});
+		BoxFile file = new BoxFile("block", "name", 0L, 0L, new byte[] {1,2,});
 		dm.insertFile(file);
 		assertThat(dm.listFiles().size(), is(1));
 		assertThat(file, equalTo(dm.listFiles().get(0)));
 		dm.deleteFile(file);
 		assertThat(dm.listFiles().size(), is(0));
+		assertThat(file, is(dm.getFile("name")));
 	}
 
 	@Test
@@ -56,7 +61,7 @@ public class DirectoryMetadataTest {
 		assertThat(folder, equalTo(dm.listFolders().get(0)));
 		dm.deleteFolder(folder);
 		assertThat(dm.listFolders().size(), is(0));
-		assertThat(dm.path.toAbsolutePath().toString(), startsWith("/tmp"));
+		assertThat(dm.path.getAbsolutePath().toString(), startsWith("/tmp"));
 	}
 
 	@Test

--- a/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
+++ b/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
@@ -58,6 +58,7 @@ public class DirectoryMetadataTest {
 		assertThat(folder, equalTo(dm.listFolders().get(0)));
 		dm.deleteFolder(folder);
 		assertThat(dm.listFolders().size(), is(0));
+		assertThat(dm.path.toAbsolutePath().toString(), startsWith("/tmp"));
 	}
 
 	@Test

--- a/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
+++ b/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.sql.SQLException;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -25,7 +26,7 @@ public class DirectoryMetadataTest {
 		bb.putLong(uuid.getMostSignificantBits());
 		bb.putLong(uuid.getLeastSignificantBits());
 
-		dm = DirectoryMetadata.newDatabase(bb.array());
+		dm = DirectoryMetadata.newDatabase("https://localhost", bb.array());
 	}
 
 	@Test
@@ -68,5 +69,23 @@ public class DirectoryMetadataTest {
 		assertThat(external, equalTo(dm.listExternals().get(0)));
 		dm.deleteExternal(external);
 		assertThat(dm.listExternals().size(), is(0));
+	}
+
+	@Test
+	public void testLastChangedBy() throws SQLException, QblStorageException {
+		assertThat(dm.deviceId, is(dm.getLastChangedBy()));
+		dm.deviceId = new byte[] {1,1};
+		dm.setLastChangedBy();
+		assertThat(dm.deviceId, is(dm.getLastChangedBy()));
+	}
+
+	@Test
+	public void testRoot() throws QblStorageException {
+		assertThat(dm.getRoot(), startsWith("https://"));
+	}
+
+	@Test
+	public void testSpecVersion() throws QblStorageException {
+		assertThat(dm.getSpecVersion(), is(0));
 	}
 }

--- a/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
+++ b/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
@@ -46,7 +46,6 @@ public class DirectoryMetadataTest {
 		assertThat(file, equalTo(dm.listFiles().get(0)));
 		dm.deleteFile(file);
 		assertThat(dm.listFiles().size(), is(0));
-		assertThat(file, is(dm.getFile("name")));
 	}
 
 	@Test

--- a/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
+++ b/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
@@ -1,26 +1,26 @@
 package de.qabel.core.storage;
 
+import de.qabel.core.exceptions.QblStorageException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
 
 public class DirectoryMetadataTest {
 
+	private DirectoryMetadata dm;
+
 	@Before
 	public void setUp() throws Exception {
-	}
-
-	@After
-	public void tearDown() throws Exception {
-
+		dm = DirectoryMetadata.newDatabase();
 	}
 
 	@Test
-	public void testInitDatabase() {
-		DirectoryMetadata dm = DirectoryMetadata.newDatabase();
+	public void testInitDatabase() throws QblStorageException {
 		byte[] version = dm.getVersion();
 		assertThat(dm.listFiles().size(), is(0));
 		assertThat(dm.listFolders().size(), is(0));
@@ -28,5 +28,13 @@ public class DirectoryMetadataTest {
 		dm.commit();
 		assertThat(dm.getVersion(), is(not(equalTo(version))));
 
+	}
+
+	@Test
+	public void testInsertFile() throws QblStorageException {
+		BoxFile file = new BoxFile("block", "name", 0l, 0l, new byte[] {1,2,});
+		dm.insertFile(file);
+		assertThat(dm.listFiles().size(), is(1));
+		assertThat(file, equalTo(dm.listFiles().get(0)));
 	}
 }

--- a/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
+++ b/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
@@ -1,0 +1,32 @@
+package de.qabel.core.storage;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+public class DirectoryMetadataTest {
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@After
+	public void tearDown() throws Exception {
+
+	}
+
+	@Test
+	public void testInitDatabase() {
+		DirectoryMetadata dm = DirectoryMetadata.newDatabase();
+		byte[] version = dm.getVersion();
+		assertThat(dm.listFiles().size(), is(0));
+		assertThat(dm.listFolders().size(), is(0));
+		assertThat(dm.listExternals().size(), is(0));
+		dm.commit();
+		assertThat(dm.getVersion(), is(not(equalTo(version))));
+
+	}
+}

--- a/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
+++ b/src/test/java/de/qabel/core/storage/DirectoryMetadataTest.java
@@ -1,8 +1,6 @@
 package de.qabel.core.storage;
 
-import de.qabel.core.crypto.CryptoUtils;
 import de.qabel.core.crypto.QblECKeyPair;
-import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.exceptions.QblStorageException;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,6 +46,7 @@ public class DirectoryMetadataTest {
 		assertThat(file, equalTo(dm.listFiles().get(0)));
 		dm.deleteFile(file);
 		assertThat(dm.listFiles().size(), is(0));
+		assertThat(file, is(dm.getFile("name")));
 	}
 
 	@Test

--- a/src/test/java/de/qabel/core/storage/LocalBackendTest.java
+++ b/src/test/java/de/qabel/core/storage/LocalBackendTest.java
@@ -1,0 +1,53 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.exceptions.QblStorageException;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static org.junit.Assert.*;
+
+public class LocalBackendTest {
+
+	private byte[] bytes;
+	private String testFile;
+	private StorageReadBackend readBackend;
+	private StorageWriteBackend writeBackend;
+
+	@Before
+	public void setupTestBackend() throws IOException {
+		Path temp = Files.createTempDirectory(null);
+		Path tempFile = Files.createTempFile(temp, null, null);
+		bytes = new byte[]{1, 2, 3, 4};
+		Files.write(tempFile, bytes);
+		readBackend = new LocalReadBackend(temp);
+		testFile = tempFile.getFileName().toString();
+		writeBackend = new LocalWriteBackend(temp);
+
+	}
+
+	@Test
+	public void testReadTempFile() throws QblStorageException, IOException {
+		assertArrayEquals(bytes, IOUtils.toByteArray(readBackend.download(testFile)));
+	}
+
+	@Test
+	public void testWriteTempFile() throws QblStorageException, IOException {
+		byte[] newBytes = bytes.clone();
+		newBytes[0] = 0;
+		writeBackend.upload(testFile, new ByteArrayInputStream(newBytes));
+		assertArrayEquals(newBytes, IOUtils.toByteArray(readBackend.download(testFile)));
+		writeBackend.delete(testFile);
+		try {
+			readBackend.download(testFile);
+			fail("Read should have failed, file is deleted");
+		} catch (QblStorageException e) {
+
+		}
+
+	}
+}

--- a/src/test/java/de/qabel/core/storage/LocalReadBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalReadBackend.java
@@ -2,6 +2,8 @@ package de.qabel.core.storage;
 
 import de.qabel.core.exceptions.QblStorageException;
 import de.qabel.core.exceptions.QblStorageNotFound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 class LocalReadBackend extends StorageReadBackend {
+
+	private static final Logger logger = LoggerFactory.getLogger(LocalReadBackend.class.getName());
 	private final Path root;
 
 
@@ -19,6 +23,7 @@ class LocalReadBackend extends StorageReadBackend {
 
 	InputStream download(String name) throws QblStorageException {
 		Path file = root.resolve(name);
+		logger.info("Downloading file path " + file.toString());
 		try {
 			return Files.newInputStream(file);
 		} catch (IOException e) {

--- a/src/test/java/de/qabel/core/storage/LocalReadBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalReadBackend.java
@@ -1,0 +1,28 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.exceptions.QblStorageException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class LocalReadBackend extends StorageReadBackend {
+	private Path root;
+
+
+	LocalReadBackend(Path root) {
+		this.root = root;
+	}
+
+
+	InputStream download(String name) throws QblStorageException {
+		Path file = root.resolve(name);
+		try {
+			return Files.newInputStream(file);
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+}

--- a/src/test/java/de/qabel/core/storage/LocalReadBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalReadBackend.java
@@ -1,6 +1,7 @@
 package de.qabel.core.storage;
 
 import de.qabel.core.exceptions.QblStorageException;
+import de.qabel.core.exceptions.QblStorageNotFound;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -8,7 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 class LocalReadBackend extends StorageReadBackend {
-	private Path root;
+	private final Path root;
 
 
 	LocalReadBackend(Path root) {
@@ -21,7 +22,7 @@ class LocalReadBackend extends StorageReadBackend {
 		try {
 			return Files.newInputStream(file);
 		} catch (IOException e) {
-			throw new QblStorageException(e);
+			throw new QblStorageNotFound(e);
 		}
 	}
 

--- a/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
@@ -1,0 +1,40 @@
+package de.qabel.core.storage;
+
+import de.qabel.core.exceptions.QblStorageException;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class LocalWriteBackend extends StorageWriteBackend {
+	private Path root;
+
+
+	LocalWriteBackend(Path root) {
+		this.root = root;
+	}
+
+	@Override
+	void upload(String name, InputStream inputStream) throws QblStorageException {
+		Path file = root.resolve(name);
+		try {
+			OutputStream output = Files.newOutputStream(file);
+			output.write(IOUtils.toByteArray(inputStream));
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		}
+	}
+
+	@Override
+	void delete(String name) throws QblStorageException {
+		Path file = root.resolve(name);
+		try {
+			Files.delete(file);
+		} catch (IOException e) {
+			throw new QblStorageException(e);
+		}
+	}
+}

--- a/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
@@ -2,6 +2,8 @@ package de.qabel.core.storage;
 
 import de.qabel.core.exceptions.QblStorageException;
 import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,6 +12,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 class LocalWriteBackend extends StorageWriteBackend {
+
+	private static final Logger logger = LoggerFactory.getLogger(LocalReadBackend.class.getName());
 	private Path root;
 
 
@@ -20,6 +24,7 @@ class LocalWriteBackend extends StorageWriteBackend {
 	@Override
 	long upload(String name, InputStream inputStream) throws QblStorageException {
 		Path file = root.resolve(name);
+		logger.info("Uploading file path " + file.toString());
 		try {
 			OutputStream output = Files.newOutputStream(file);
 			output.write(IOUtils.toByteArray(inputStream));

--- a/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
@@ -18,11 +18,12 @@ class LocalWriteBackend extends StorageWriteBackend {
 	}
 
 	@Override
-	void upload(String name, InputStream inputStream) throws QblStorageException {
+	long upload(String name, InputStream inputStream) throws QblStorageException {
 		Path file = root.resolve(name);
 		try {
 			OutputStream output = Files.newOutputStream(file);
 			output.write(IOUtils.toByteArray(inputStream));
+			return Files.getLastModifiedTime(file).toMillis();
 		} catch (IOException e) {
 			throw new QblStorageException(e);
 		}

--- a/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
@@ -37,6 +37,7 @@ class LocalWriteBackend extends StorageWriteBackend {
 	@Override
 	void delete(String name) throws QblStorageException {
 		Path file = root.resolve(name);
+		logger.info("Deleting file path " + file.toString());
 		try {
 			Files.delete(file);
 		} catch (IOException e) {

--- a/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
+++ b/src/test/java/de/qabel/core/storage/LocalWriteBackend.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 class LocalWriteBackend extends StorageWriteBackend {
@@ -26,6 +27,7 @@ class LocalWriteBackend extends StorageWriteBackend {
 		Path file = root.resolve(name);
 		logger.info("Uploading file path " + file.toString());
 		try {
+			Files.createDirectories(root.resolve("blocks"));
 			OutputStream output = Files.newOutputStream(file);
 			output.write(IOUtils.toByteArray(inputStream));
 			return Files.getLastModifiedTime(file).toMillis();
@@ -40,6 +42,8 @@ class LocalWriteBackend extends StorageWriteBackend {
 		logger.info("Deleting file path " + file.toString());
 		try {
 			Files.delete(file);
+		} catch (NoSuchFileException e) {
+			// ignore this just like the S3 API
 		} catch (IOException e) {
 			throw new QblStorageException(e);
 		}

--- a/src/test/java/de/qabel/core/storage/S3BackendTest.java
+++ b/src/test/java/de/qabel/core/storage/S3BackendTest.java
@@ -1,0 +1,43 @@
+package de.qabel.core.storage;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import de.qabel.core.exceptions.QblStorageException;
+import de.qabel.core.storage.S3ReadBackend;
+import de.qabel.core.storage.S3WriteBackend;
+import de.qabel.core.storage.StorageReadBackend;
+import de.qabel.core.storage.StorageWriteBackend;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.UUID;
+
+public class S3BackendTest {
+
+	@Test
+	public void testSimple() throws Exception {
+		String prefix = UUID.randomUUID().toString();
+		StorageReadBackend readBackend = new S3ReadBackend("https://qabel.s3.amazonaws.com/"+prefix);
+		StorageReadBackend bucketReadBackend = new S3ReadBackend("qabel", prefix);
+
+		DefaultAWSCredentialsProviderChain chain = new DefaultAWSCredentialsProviderChain();
+		StorageWriteBackend writeBackend = new S3WriteBackend(chain.getCredentials(), "qabel", prefix);
+		byte[] bytes = new byte[]{1, 2, 3, 4};
+		String name = UUID.randomUUID().toString();
+
+		writeBackend.upload(name, new ByteArrayInputStream(bytes));
+		InputStream bucketDownload = bucketReadBackend.download(name);
+		assertArrayEquals(bytes, IOUtils.toByteArray(bucketDownload));
+		InputStream download = readBackend.download(name);
+		assertArrayEquals(bytes, IOUtils.toByteArray(download));
+		writeBackend.delete(name);
+		try {
+			readBackend.download(name);
+			fail("Download should have failed");
+		} catch (QblStorageException e) {
+
+		}
+	}
+}


### PR DESCRIPTION
Implementation of #390 

# Work in Progress

The code now lives in the qabel-android repo ( https://github.com/Qabel/qabel-android/pull/6 ). This version here should be moved to the qabel-desktop reopo.

* [ ] Create and list prefixes #391 https://github.com/Qabel/qabel-accounting/issues/23
* [x] Generate device id
* [ ] Save device id locally #395 
* [x] Internal backend for S3 upload/download/delete
* [x] Create and update directory metadata files #394
* [x] Volume creation
* [x] Directory creation
* [x] File Upload/Download
* [x] Volume browsing
* [x] File update
* [x] File update conflict solution
* [x] Prevent name clashes between files, folders and externals
* [x] Folder update via delete and insert
* [ ] JavaDocs for the public interface
* [x] Upload large files (Bug on Android currently)
* [x] Name clashes on android
* [x] Folder-name and external-name as primary key (same as with the file)
* [ ] Folder sharing + drop messages
* [ ] Single File Sharing
* [ ] Unsharing