### PR TITLE
Changes the port from 6000 to 5000

### DIFF
--- a/src/test/java/de/qabel/core/MultiPartCryptoTest.java
+++ b/src/test/java/de/qabel/core/MultiPartCryptoTest.java
@@ -98,19 +98,19 @@ public class MultiPartCryptoTest {
         Collection<DropURL> alicesDrops = new ArrayList<DropURL>();
         alicesDrops.add(
                 new DropURL(
-                        "http://localhost:6000/12345678901234567890123456789012345678alice"));
+                        "http://localhost:5000/12345678901234567890123456789012345678alice"));
         alice = new Identity("Alice", alicesDrops, alicesKey);
 
         QblECKeyPair bobsKey = new QblECKeyPair();
         Identity bob = new Identity("Bob", new ArrayList<DropURL>(), bobsKey);
         bob.addDrop(new DropURL(
-        		"http://localhost:6000/1234567890123456789012345678901234567890bob"));
+				"http://localhost:5000/1234567890123456789012345678901234567890bob"));
 
 		Contact alicesContact = new Contact(alice, "Bob", null, bobsKey.getPub());
-        alicesContact.addDrop(new DropURL("http://localhost:6000/1234567890123456789012345678901234567890bob"));
+        alicesContact.addDrop(new DropURL("http://localhost:5000/1234567890123456789012345678901234567890bob"));
 
         Contact bobsContact = new Contact(bob, "Alice", null, alicesKey.getPub());
-        alicesContact.addDrop(new DropURL("http://localhost:6000/12345678901234567890123456789012345678alice"));
+        alicesContact.addDrop(new DropURL("http://localhost:5000/12345678901234567890123456789012345678alice"));
 
         contacts = new Contacts();
         contacts.put(alicesContact);

--- a/src/test/java/de/qabel/core/drop/DropActorTest.java
+++ b/src/test/java/de/qabel/core/drop/DropActorTest.java
@@ -15,8 +15,8 @@ import java.security.InvalidKeyException;
 import java.util.HashSet;
 
 public class DropActorTest {
-    private static final String iUrl = "http://localhost:6000/123456789012345678901234567890123456789012c";
-    private static String cUrl = "http://localhost:6000/123456789012345678901234567890123456789012d";
+    private static final String iUrl = "http://localhost:5000/123456789012345678901234567890123456789012c";
+    private static String cUrl = "http://localhost:5000/123456789012345678901234567890123456789012d";
 	private static final String DB_NAME = "DropActorTest.sqlite";
 	private Identity sender, recipient;
     private Contact senderContact, recipientContact;

--- a/src/test/java/de/qabel/core/http/DropHTTPTest.java
+++ b/src/test/java/de/qabel/core/http/DropHTTPTest.java
@@ -24,18 +24,18 @@ public class DropHTTPTest {
 	public void setUp() {
 		try {
 			workingUri = new URI(
-					"http://localhost:6000/abcdefghijklmnopqrstuvwxyzabcdefgworkingUrl");
+					"http://localhost:5000/abcdefghijklmnopqrstuvwxyzabcdefgworkingUrl");
 
-			tooShortUri = new URI("http://localhost:6000/IAmTooShort");
+			tooShortUri = new URI("http://localhost:5000/IAmTooShort");
 
 			notExistingUri = new URI(
-					"http://localhost:6000/abcdefghijklmnopqrstuvwxyzabcnotExistingUrl");
+					"http://localhost:5000/abcdefghijklmnopqrstuvwxyzabcnotExistingUrl");
 
             shouldContainMessagesUri = new URI(
-                    "http://localhost:6000/abcdefghijklmnopqrstuvshouldContainMessages");
+                    "http://localhost:5000/abcdefghijklmnopqrstuvshouldContainMessages");
 
             shouldContainNoNewMessagesSinceDateUri = new URI(
-                    "http://localhost:6000/abcdefghshouldContainNoNewMessagesSinceDate");
+                    "http://localhost:5000/abcdefghshouldContainNoNewMessagesSinceDate");
 
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
@@ -237,7 +237,7 @@ public class DropHTTPTest {
 		assertFalse(result.isOk());
 	}
 
-	// HEAD 404 + SINCE
+	// HEAD 204 + SINCE
 	@Test
 	public void shouldBeEmptyWithSinceDate() {
 		// Given


### PR DESCRIPTION
The new DropServer does not like port 6000, so we use the flask standard port 5000.
Needed for qabel/qabel-drop#26