### PR TITLE
fixed interface of Persistence

### DIFF
--- a/src/main/java/de/qabel/core/config/Persistence.java
+++ b/src/main/java/de/qabel/core/config/Persistence.java
@@ -100,21 +100,21 @@ public abstract class Persistence<T> {
 	 * @param object Entity to persist
 	 * @return Result of the operation
 	 */
-	protected abstract boolean persistEntity(Persistable object);
+	public abstract boolean persistEntity(Persistable object);
 
 	/**
 	 * Updates a previously stored entity
 	 * @param object Entity to replace stored entity with
 	 * @return Result of the operation
 	 */
-	protected abstract boolean updateEntity(Persistable object);
+	public abstract boolean updateEntity(Persistable object);
 
 	/**
 	 * Updates a previously stored entity or persist a new entity
 	 * @param object Entity to replace stored entity with
 	 * @return Result of the operation
 	 */
-	protected abstract boolean updateOrPersistEntity(Persistable object);
+	public abstract boolean updateOrPersistEntity(Persistable object);
 
 	/**
 	 * Removes a persisted entity
@@ -122,7 +122,7 @@ public abstract class Persistence<T> {
 	 * @param cls Class of persisted entity
 	 * @return Result of the operation
 	 */
-	protected abstract boolean removeEntity(String id, Class cls);
+	public abstract boolean removeEntity(String id, Class<? extends Persistable> cls);
 
 	/**
 	 * Get an entity
@@ -130,21 +130,21 @@ public abstract class Persistence<T> {
 	 * @param cls Class of the entity to receive
 	 * @return Stored entity or null if entity not found
 	 */
-	protected abstract Persistable getEntity(String id, Class cls);
+	public abstract <U extends Persistable> U getEntity(String id, Class<? extends U> cls);
 
 	/**
 	 * Get all entities of the provides Class
 	 * @param cls Class to get all stored entities for
 	 * @return List of stored entities
 	 */
-	protected abstract List<Persistable> getEntities(Class cls);
+	public abstract <U extends Persistable> List<U> getEntities(Class<? extends U> cls);
 
 	/**
 	 * Drops the table for the provided Class
 	 * @param cls Class to drop table for
 	 * @return Result of the operation
 	 */
-	protected abstract boolean dropTable(Class cls);
+	protected abstract boolean dropTable(Class<? extends Persistable> cls);
 
 	/**
 	 * Derives the encryption key from the password and a salt.

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -271,7 +271,7 @@ public class SQLitePersistence extends Persistence<String> {
 	}
 
 	@Override
-	protected boolean updateEntity(Persistable object) {
+	public boolean updateEntity(Persistable object) {
 		if (object == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}

--- a/src/main/java/de/qabel/core/config/SQLitePersistence.java
+++ b/src/main/java/de/qabel/core/config/SQLitePersistence.java
@@ -323,21 +323,21 @@ public class SQLitePersistence extends Persistence<String> {
 	}
 
 	@Override
-	public Persistable getEntity(String id, Class cls) {
+	public <U extends Persistable> U getEntity(String id, Class<? extends U> cls) {
 		if (id == null || cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
 		if (id.length() == 0) {
 			throw new IllegalArgumentException("ID cannot be empty!");
 		}
-		Persistable object = null;
+		U object = null;
 		String sql = "SELECT BLOB, NONCE FROM " +
 				"\"" + cls.getCanonicalName() + "\"" +
 				" WHERE ID = ?";
 		try (PreparedStatement statement = c.prepareStatement(sql)){
 			statement.setString(1, id);
 			try (ResultSet rs = statement.executeQuery()) {
-				object = (Persistable) deserialize(id, rs.getBytes("BLOB"), rs.getBytes("NONCE"));
+				object = (U) deserialize(id, rs.getBytes("BLOB"), rs.getBytes("NONCE"));
 			}
 		} catch (SQLException | IllegalArgumentException e) {
 			logger.error("Cannot get entity!", e);
@@ -346,17 +346,17 @@ public class SQLitePersistence extends Persistence<String> {
 	}
 
 	@Override
-	public List<Persistable> getEntities(Class cls) {
+	public  <U extends Persistable> List<U> getEntities(Class<? extends U> cls) {
 		if (cls == null) {
 			throw new IllegalArgumentException("Arguments cannot be null!");
 		}
-		List<Persistable> objects = new ArrayList<>();
+		List<U> objects = new ArrayList<>();
 		String sql = "SELECT ID, BLOB, NONCE FROM " +
 				"\"" + cls.getCanonicalName() + "\"";
 		try (Statement statement = c.createStatement()){
 			try (ResultSet rs = statement.executeQuery(sql)) {
 				while (rs.next()) {
-					objects.add((Persistable) deserialize(new String(rs.getBytes("ID")), rs.getBytes("BLOB"), rs.getBytes("NONCE")));
+					objects.add((U) deserialize(new String(rs.getBytes("ID")), rs.getBytes("BLOB"), rs.getBytes("NONCE")));
 				}
 			}
 		} catch (SQLException | IllegalArgumentException e) {

--- a/src/test/java/de/qabel/core/config/PersistenceTest.java
+++ b/src/test/java/de/qabel/core/config/PersistenceTest.java
@@ -43,7 +43,7 @@ public class PersistenceTest {
 		Assert.assertTrue(persistence.persistEntity(pto));
 		Assert.assertTrue(persistence.persistEntity(pto2));
 
-		List<Persistable> objects = persistence.getEntities(PersistenceTestObject.class);
+		List<PersistenceTestObject> objects = persistence.getEntities(PersistenceTestObject.class);
 		Assert.assertEquals(2, objects.size());
 		Assert.assertTrue(objects.contains(pto));
 		Assert.assertTrue(objects.contains(pto2));
@@ -51,7 +51,7 @@ public class PersistenceTest {
 
 	@Test
 	public void getEntitiesEmptyTest() {
-		List<Persistable> objects = persistence.getEntities(PersistenceTestObject.class);
+		List<PersistenceTestObject> objects = persistence.getEntities(PersistenceTestObject.class);
 		Assert.assertEquals(0, objects.size());
 	}
 


### PR DESCRIPTION
Most methods were protected, thus couldn't be accessed from outside, now they are public.
Additionally, `getEntity` and `getEntities` returned instances of Persistence only even though the exact Class (subclass of Persistence) is known. This fixes those signatures to return the correct type.

And both commits should reference Qabel/qabel-desktop#53 , I just mixed up the issue numbers.