### PR TITLE
Change visibility of registerSender in DropMessage to public

### DIFF
--- a/src/main/java/de/qabel/core/drop/DropMessage.java
+++ b/src/main/java/de/qabel/core/drop/DropMessage.java
@@ -75,7 +75,7 @@ public class DropMessage implements Serializable {
      * @param sender Entity to be registered as sender.
      * @return true if the given sender matches the senderKeyId, otherwise false.
      */
-    boolean registerSender(Entity sender) {
+    public boolean registerSender(Entity sender) {
     	if (!senderKeyId.equals(sender.getKeyIdentifier())) {
     		return false;
     	}


### PR DESCRIPTION
Required to use this method from qabel-android for receiving DropMessages without the DropActor.