### PR TITLE
allow concurrent cryption on CryptoUtils

### DIFF
--- a/src/main/java/de/qabel/core/crypto/CryptoUtils.java
+++ b/src/main/java/de/qabel/core/crypto/CryptoUtils.java
@@ -40,13 +40,11 @@ public class CryptoUtils {
 			.getName());
 
 	private SecureRandom secRandom;
-	private GCMBlockCipher gcmCipher;
 	private Mac hmac;
 	private CipherKeyGenerator keyGenerator;
 
 	public CryptoUtils() {
 		secRandom = new SecureRandom();
-		gcmCipher = new GCMBlockCipher(new AESEngine());
 		hmac = new HMac(new SHA512Digest());
 
 		//New key generator needs random for initialization
@@ -129,6 +127,7 @@ public class CryptoUtils {
 			nonce = getRandomBytes(SYMM_NONCE_SIZE_BYTE);
 		}
 
+		GCMBlockCipher gcmCipher = new GCMBlockCipher(new AESEngine());
 		try {
 			gcmCipher.init(true, new AEADParameters(key, MAC_BIT, nonce, null));
 		} catch (IllegalArgumentException e) {
@@ -184,6 +183,7 @@ public class CryptoUtils {
 			throw e;
 		}
 
+		GCMBlockCipher gcmCipher = new GCMBlockCipher(new AESEngine());
 		try {
 			gcmCipher.init(false, new AEADParameters(key, MAC_BIT, nonce, null));
 		} catch (IllegalArgumentException e) {

--- a/src/test/java/de/qabel/core/crypto/DelayedStream.java
+++ b/src/test/java/de/qabel/core/crypto/DelayedStream.java
@@ -1,0 +1,48 @@
+package de.qabel.core.crypto;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class DelayedStream extends FilterInputStream {
+	private boolean blockOnRead = true;
+	private boolean blocked = false;
+
+	protected DelayedStream(InputStream in) {
+		super(in);
+	}
+
+	@Override
+	public int read() throws IOException {
+		while(blocked)
+			Thread.yield();
+		if (blockOnRead)
+			block();
+		return super.read();
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		while(blocked)
+			Thread.yield();
+		if (blockOnRead)
+			block();
+		return super.read(b, off, len);
+	}
+
+	public void block() {
+		blocked = true;
+	}
+
+	public void unblock() {
+		blocked = false;
+	}
+
+	public void setBlockOnRead(boolean blockOnRead) {
+		this.blockOnRead = blockOnRead;
+	}
+
+	public boolean isBlocked() {
+		return blocked;
+	}
+}


### PR DESCRIPTION
Currently, when the same instance of cryptoUtils is used for multiple de- or encryptions, those need to be sequential. Concurrent calls use the same `GCMBlockCipher` instance and at least one of them will fail.

cause for Qabel/qabel-desktop#125 