### PR TITLE
#451 don't reuse HMac on CryptoUtils to make its usage thread safe, too

### DIFF
--- a/src/main/java/de/qabel/core/crypto/CryptoUtils.java
+++ b/src/main/java/de/qabel/core/crypto/CryptoUtils.java
@@ -40,12 +40,10 @@ public class CryptoUtils {
 			.getName());
 
 	private SecureRandom secRandom;
-	private Mac hmac;
 	private CipherKeyGenerator keyGenerator;
 
 	public CryptoUtils() {
 		secRandom = new SecureRandom();
-		hmac = new HMac(new SHA512Digest());
 
 		//New key generator needs random for initialization
 		keyGenerator = new CipherKeyGenerator();
@@ -246,6 +244,7 @@ public class CryptoUtils {
 		// expected length, but it might improve the performance
 		KeyParameter key = new KeyParameter(secret);
 		ByteArrayOutputStream bs = new ByteArrayOutputStream(info.length + 1 + 32 + extraSecret.length);
+		HMac hmac = new HMac(new SHA512Digest());
 		for (int c = 0; c <= Math.ceil((double) outputLen / H_LEN) - 1; c++) {
 			try {
 				bs.write(info);

--- a/src/test/java/de/qabel/core/crypto/CryptoUtilsTest.java
+++ b/src/test/java/de/qabel/core/crypto/CryptoUtilsTest.java
@@ -62,8 +62,9 @@ public class CryptoUtilsTest {
 			}
 		};
 		decryptor.start();
-		while(!cipherStream1.isBlocked())
+		while (!cipherStream1.isBlocked()) {
 			Thread.sleep(10);
+		}
 
 		File testFileDec2 = new File(testFileName + ".dec2");
 		InputStream cipherStream2 = new FileInputStream(testFileEnc);

--- a/src/test/java/de/qabel/core/crypto/DelayedStream.java
+++ b/src/test/java/de/qabel/core/crypto/DelayedStream.java
@@ -14,19 +14,23 @@ public class DelayedStream extends FilterInputStream {
 
 	@Override
 	public int read() throws IOException {
-		while(blocked)
+		while (blocked) {
 			Thread.yield();
-		if (blockOnRead)
+		}
+		if (blockOnRead) {
 			block();
+		}
 		return super.read();
 	}
 
 	@Override
 	public int read(byte[] b, int off, int len) throws IOException {
-		while(blocked)
+		while (blocked) {
 			Thread.yield();
-		if (blockOnRead)
+		}
+		if (blockOnRead) {
 			block();
+		}
 		return super.read(b, off, len);
 	}
 


### PR DESCRIPTION
see #451 for details

srsly don't know how to test this as the margin for threading issues is the `hmac.update` itself and the `write` to a local memorybased stream.

+fixed code style issues mentioned by @L-Henke 