### PR TITLE
#488 on filename conflict, the remote file is renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [Unreleased]
+### CHANGES
+- AbstractNavigation::upload no longer throws QblStorageNameConflictExceptions (they are just resolved)
+- #488 FileNameConflicts are resolved in reverse order. The remote file is renamed now.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.cache.scope = :box
   end
 
+  config.vm.network "private_network", ip: "192.168.50.42"
+
   config.vm.network "forwarded_port", guest: 5000, host: 5000, auto_correct: true
   config.vm.network "forwarded_port", guest: 9696, host: 9696, auto_correct: true
   config.vm.network "forwarded_port", guest: 9697, host: 9697, auto_correct: true
@@ -54,6 +56,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             postgresql-client-9.5
         easy_install pip
 
+        sudo service postgresql start
         echo "CREATE DATABASE qabel_drop; CREATE USER qabel WITH PASSWORD 'qabel_test'; GRANT ALL PRIVILEGES ON DATABASE qabel_drop TO qabel;" | sudo -u postgres psql postgres
         echo "CREATE DATABASE block_dummy; CREATE USER block_dummy WITH PASSWORD 'qabel_test_dummy'; GRANT ALL PRIVILEGES ON DATABASE block_dummy TO block_dummy;" | sudo -u postgres psql postgres
 
@@ -69,6 +72,7 @@ SCRIPT
         set -e
         cd /vagrant
 
+        sudo service postgresql start
         DIRHASH=$(pwd | shasum | cut -d" " -f1)
 
         function waitForPort {
@@ -105,7 +109,7 @@ SCRIPT
         fi
         DROP_VENV="venv_"${DIRHASH}
         if [ ! -d ${DROP_VENV} ]; then
-          virtualenv --no-site-packages --python=python3.4 ${DROP_VENV}
+          virtualenv --no-site-packages --python=python3.5 ${DROP_VENV}
         fi
         source ${DROP_VENV}"/bin/activate"
         echo "installing dependencies..."
@@ -138,7 +142,7 @@ SCRIPT
             cat accounting.pid | xargs kill || echo "already gone"
         fi
         if [ ! -d ${ACCOUNTING_VENV} ]; then
-          virtualenv --no-site-packages --always-copy --python=python3.4 ${ACCOUNTING_VENV}
+          virtualenv --no-site-packages --always-copy --python=python3.5 ${ACCOUNTING_VENV}
         fi
         source ${ACCOUNTING_VENV}"/bin/activate"
         echo "installing dependencies..."

--- a/box/src/main/java/de/qabel/box/storage/BoxObject.java
+++ b/box/src/main/java/de/qabel/box/storage/BoxObject.java
@@ -33,4 +33,8 @@ public abstract class BoxObject extends Observable implements Comparable<BoxObje
     }
 
     public abstract String getRef();
+
+    public void setName(String name) {
+        this.name = name;
+    }
 }

--- a/box/src/main/java/de/qabel/box/storage/DirectoryMetadata.java
+++ b/box/src/main/java/de/qabel/box/storage/DirectoryMetadata.java
@@ -280,10 +280,9 @@ public class DirectoryMetadata extends AbstractMetadata {
         }
     }
 
-
     public void insertFile(BoxFile file) throws QblStorageException {
         int type = isA(file.getName());
-        if (type != TYPE_NONE && type != TYPE_FILE) {
+        if (type != TYPE_NONE) {
             throw new QblStorageNameConflict(file.getName());
         }
         try {
@@ -325,7 +324,7 @@ public class DirectoryMetadata extends AbstractMetadata {
 
     public void insertFolder(BoxFolder folder) throws QblStorageException {
         int type = isA(folder.getName());
-        if (type != TYPE_NONE && type != TYPE_FOLDER) {
+        if (type != TYPE_NONE) {
             throw new QblStorageNameConflict(folder.getName());
         }
         executeStatement(() -> {
@@ -415,7 +414,7 @@ public class DirectoryMetadata extends AbstractMetadata {
 
     void insertExternal(BoxExternalReference external) throws QblStorageException {
         int type = isA(external.name);
-        if (type != TYPE_NONE && type != TYPE_EXTERNAL) {
+        if (type != TYPE_NONE) {
             throw new QblStorageNameConflict(external.name);
         }
         try {
@@ -471,6 +470,30 @@ public class DirectoryMetadata extends AbstractMetadata {
         } catch (SQLException e) {
             throw new QblStorageException(e);
         }
+    }
+
+    public BoxFolder getFolder(String name) throws QblStorageException {
+        try (PreparedStatement statement = connection.prepareStatement(
+            "SELECT ref, name, key FROM folders WHERE name=?"
+        )) {
+            statement.setString(1, name);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return new BoxFolder(rs.getString(1), rs.getString(2), rs.getBytes(3));
+                }
+                return null;
+            }
+        } catch (SQLException e) {
+            throw new QblStorageException(e);
+        }
+    }
+
+    public boolean hasFile(String name) throws QblStorageException {
+        return getFile(name) != null;
+    }
+
+    public boolean hasFolder(String name) throws QblStorageException {
+        return getFolder(name) != null;
     }
 
     int isA(String name) throws QblStorageException {

--- a/box/src/main/java/de/qabel/box/storage/command/CreateFileChange.java
+++ b/box/src/main/java/de/qabel/box/storage/command/CreateFileChange.java
@@ -1,0 +1,9 @@
+package de.qabel.box.storage.command;
+
+import de.qabel.box.storage.BoxFile;
+
+public class CreateFileChange extends UpdateFileChange {
+    public CreateFileChange(BoxFile newFile) {
+        super(null, newFile);
+    }
+}

--- a/box/src/main/java/de/qabel/box/storage/command/UpdateFileChange.java
+++ b/box/src/main/java/de/qabel/box/storage/command/UpdateFileChange.java
@@ -1,0 +1,60 @@
+package de.qabel.box.storage.command;
+
+import de.qabel.box.storage.BoxFile;
+import de.qabel.box.storage.DirectoryMetadata;
+import de.qabel.box.storage.exceptions.QblStorageException;
+import de.qabel.box.storage.exceptions.QblStorageNameConflict;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UpdateFileChange implements DirectoryMetadataChange<UpdateFileChange.Result> {
+    private static final Logger logger = LoggerFactory.getLogger(UpdateFileChange.class);
+    private BoxFile oldFile;
+    private BoxFile newFile;
+
+    public UpdateFileChange(BoxFile oldFile, BoxFile newFile) {
+        this.oldFile = oldFile;
+        this.newFile = newFile;
+    }
+
+    @Override
+    public Result execute(DirectoryMetadata dm) throws QblStorageException {
+        String filename = newFile.getName();
+        BoxFile currentFile = dm.getFile(filename);
+        handleConflict(currentFile, dm);
+        return new Result();
+    }
+
+    private void handleConflict(BoxFile currentFile, DirectoryMetadata dm) throws QblStorageException {
+        if (currentFile == null) {
+            try {
+                dm.insertFile(newFile);
+            } catch (QblStorageNameConflict e) {
+                // name clash with a folder or external
+                newFile.setName(conflictName(newFile));
+                // try again until we get no name clash
+                handleConflict(dm.getFile(newFile.getName()), dm);
+            }
+        } else if (currentFile.equals(oldFile)) {
+            logger.info("No conflict for the file " + newFile.getName());
+            dm.insertFile(newFile);
+        } else {
+            logger.info("Inserting conflict marked file");
+            newFile.setName(conflictName(newFile));
+            if (oldFile != null) {
+                dm.deleteFile(oldFile);
+            }
+            if (dm.getFile(newFile.getName()) == null) {
+                dm.insertFile(newFile);
+            }
+        }
+    }
+
+    private String conflictName(BoxFile local) {
+        return local.getName() + "_conflict";
+    }
+
+    public static class Result {
+
+    }
+}

--- a/box/src/test/java/de/qabel/box/storage/BoxVolumeTest.java
+++ b/box/src/test/java/de/qabel/box/storage/BoxVolumeTest.java
@@ -269,14 +269,55 @@ public abstract class BoxVolumeTest {
     public void testConflictFileUpdate() throws QblStorageException, IOException {
         BoxNavigation nav = setupConflictNav1();
         BoxNavigation nav2 = setupConflictNav2();
-        File file = new File(testFileName);
-        nav.upload(DEFAULT_UPLOAD_FILENAME, file);
-        nav2.upload(DEFAULT_UPLOAD_FILENAME, file);
-        nav2.commit();
-        nav.commit();
-        assertThat(nav.listFiles().size(), is(2));
+        File file1 = new File(testFileName);
+        File file2 = tmpFileWithSize(0L);
+        try {
+            nav.upload(DEFAULT_UPLOAD_FILENAME, file1);
+            nav2.upload(DEFAULT_UPLOAD_FILENAME, file2);
+            nav2.commit();
+            nav.commit();
+            assertThat(nav.listFiles().size(), is(2));
+            assertThat(nav.getFile(DEFAULT_UPLOAD_FILENAME).size, is(0L)); // file2 gets the name
+            assertThat(nav.getFile(DEFAULT_UPLOAD_FILENAME + "_conflict").size, is(file1.length())); // file1 renamed
+        } finally {
+            file2.delete();
+        }
     }
 
+    private File tmpFileWithSize(Long size) throws IOException {
+        Path file = Files.createTempFile("qbltmp", ".deleteme");
+        StringBuffer content = new StringBuffer();
+        for (int i = 0; i < size; i++) {
+            content.append("1");
+        }
+        return  file.toFile();
+    }
+/*
+    @Test
+    public void testSuccessiveConflictFileUpdate() throws QblStorageException, IOException {
+        BoxNavigation nav = setupConflictNav1();
+        BoxNavigation nav2 = setupConflictNav2();
+        File file1 = new File(testFileName);
+        File file2 = tmpFileWithSize(2L);
+        File file3 = tmpFileWithSize(3L);
+        try {
+            nav.upload(DEFAULT_UPLOAD_FILENAME, file3);
+            nav2.upload(DEFAULT_UPLOAD_FILENAME, file1);
+            nav2.upload(DEFAULT_UPLOAD_FILENAME + "_conflict", file2);
+            nav2.commit();
+            nav.commit();
+            assertThat(nav.listFiles().size(), is(3));
+            assertThat(nav.getFile(DEFAULT_UPLOAD_FILENAME).size, is(3L)); // file3 gets the name
+            assertThat(
+                nav.getFile(DEFAULT_UPLOAD_FILENAME + "_conflict_conflict").size,
+                is(file1.length())
+            ); // file1 renamed
+        } finally {
+            file2.delete();
+            file3.delete();
+        }
+    }
+*/
     @Test
     public void testFoldersAreMergedOnConflict() throws Exception {
         BoxNavigation nav = setupConflictNav1();
@@ -351,11 +392,13 @@ public abstract class BoxVolumeTest {
         }
     }
 
-    @Test(expected = QblStorageNameConflict.class)
+    @Test
     public void testFileNameConflict() throws QblStorageException {
         BoxNavigation nav = volume.navigate();
         nav.createFolder(DEFAULT_UPLOAD_FILENAME);
         nav.upload(DEFAULT_UPLOAD_FILENAME, new File(testFileName));
+        assertTrue(nav.hasFolder(DEFAULT_UPLOAD_FILENAME));
+        assertTrue(nav.hasFile(DEFAULT_UPLOAD_FILENAME + "_conflict"));
     }
 
     @Test(expected = QblStorageNameConflict.class)

--- a/box/src/test/java/de/qabel/box/storage/BoxVolumeTest.java
+++ b/box/src/test/java/de/qabel/box/storage/BoxVolumeTest.java
@@ -272,8 +272,8 @@ public abstract class BoxVolumeTest {
         File file1 = new File(testFileName);
         File file2 = tmpFileWithSize(0L);
         try {
-            nav.upload(DEFAULT_UPLOAD_FILENAME, file1);
-            nav2.upload(DEFAULT_UPLOAD_FILENAME, file2);
+            nav2.upload(DEFAULT_UPLOAD_FILENAME, file1);
+            nav.upload(DEFAULT_UPLOAD_FILENAME, file2);
             nav2.commit();
             nav.commit();
             assertThat(nav.listFiles().size(), is(2));
@@ -290,9 +290,10 @@ public abstract class BoxVolumeTest {
         for (int i = 0; i < size; i++) {
             content.append("1");
         }
+        Files.write(file, content.toString().getBytes());
         return  file.toFile();
     }
-/*
+
     @Test
     public void testSuccessiveConflictFileUpdate() throws QblStorageException, IOException {
         BoxNavigation nav = setupConflictNav1();
@@ -301,9 +302,9 @@ public abstract class BoxVolumeTest {
         File file2 = tmpFileWithSize(2L);
         File file3 = tmpFileWithSize(3L);
         try {
-            nav.upload(DEFAULT_UPLOAD_FILENAME, file3);
             nav2.upload(DEFAULT_UPLOAD_FILENAME, file1);
             nav2.upload(DEFAULT_UPLOAD_FILENAME + "_conflict", file2);
+            nav.upload(DEFAULT_UPLOAD_FILENAME, file3);
             nav2.commit();
             nav.commit();
             assertThat(nav.listFiles().size(), is(3));
@@ -317,7 +318,7 @@ public abstract class BoxVolumeTest {
             file3.delete();
         }
     }
-*/
+
     @Test
     public void testFoldersAreMergedOnConflict() throws Exception {
         BoxNavigation nav = setupConflictNav1();
@@ -397,8 +398,8 @@ public abstract class BoxVolumeTest {
         BoxNavigation nav = volume.navigate();
         nav.createFolder(DEFAULT_UPLOAD_FILENAME);
         nav.upload(DEFAULT_UPLOAD_FILENAME, new File(testFileName));
-        assertTrue(nav.hasFolder(DEFAULT_UPLOAD_FILENAME));
-        assertTrue(nav.hasFile(DEFAULT_UPLOAD_FILENAME + "_conflict"));
+        assertTrue(nav.hasFolder(DEFAULT_UPLOAD_FILENAME + "_conflict"));
+        assertTrue(nav.hasFile(DEFAULT_UPLOAD_FILENAME));
     }
 
     @Test(expected = QblStorageNameConflict.class)
@@ -413,13 +414,14 @@ public abstract class BoxVolumeTest {
         BoxNavigation nav = setupConflictNav1();
         BoxNavigation nav2 = setupConflictNav2();
         File file = new File(testFileName);
-        nav.upload(DEFAULT_UPLOAD_FILENAME, file);
         nav2.createFolder(DEFAULT_UPLOAD_FILENAME);
+        nav.upload(DEFAULT_UPLOAD_FILENAME, file);
         nav2.commit();
         nav.commit();
         assertThat(nav.listFiles().size(), is(1));
         assertThat(nav.listFolders().size(), is(1));
-        assertThat(nav.listFiles().get(0).name, startsWith("foobar_conflict"));
+        assertThat(nav.listFiles().get(0).name, is("foobar"));
+        assertThat(nav.listFolders().get(0).name, startsWith("foobar_conflict"));
     }
 
     @Test
@@ -443,8 +445,8 @@ public abstract class BoxVolumeTest {
         BoxNavigation nav = setupConflictNav1();
         BoxNavigation nav2 = setupConflictNav2();
         File file = new File(testFileName);
-        nav.createFolder(DEFAULT_UPLOAD_FILENAME);
         nav2.upload(DEFAULT_UPLOAD_FILENAME, file);
+        nav.createFolder(DEFAULT_UPLOAD_FILENAME);
         nav2.commit();
         nav.commit();
         assertThat(nav.listFiles().size(), is(1));

--- a/start-servers.sh
+++ b/start-servers.sh
@@ -36,7 +36,7 @@ if [ -f drop.pid ]; then
 fi
 DROP_VENV="venv_"${DIRHASH}
 if [ ! -d ${DROP_VENV} ]; then
-  virtualenv --no-site-packages --python=python3.4 ${DROP_VENV}
+  virtualenv --no-site-packages --python=python3.5 ${DROP_VENV}
 fi
 source "${DROP_VENV}/bin/activate"
 echo "installing dependencies..."
@@ -68,7 +68,7 @@ if [ -f accounting.pid ]; then
     cat accounting.pid | xargs kill || echo "already gone"
 fi
 if [ ! -d ${ACCOUNTING_VENV} ]; then
-  virtualenv --no-site-packages --always-copy --python=python3.4 ${ACCOUNTING_VENV}
+  virtualenv --no-site-packages --always-copy --python=python3.5 ${ACCOUNTING_VENV}
 fi
 source "${ACCOUNTING_VENV}/bin/activate"
 echo "installing dependencies..."


### PR DESCRIPTION
the core part of #488.
I'm still searching a way of reusing that code of the `UpdateFileChange`-Command for the sync (one layer above the AbstractNavigation). Unfortunately, the sync code will need the SyncIndex to determine if the "conflict" / "information mismatch" is due to a remote change (real conflict) or a preceding upload (just looks like a conflict like create file => change file)