### PR TITLE
0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd /vagrant
 # Usage
 
 Currently, we do not provide a distribution of the Qabel Core Library via Maven Repositories.
-Thus, you have to include it via the artifact that you may find after the build at `build/libs/qabel-core-0.1.jar`.
+Thus, you have to include it via the artifact that you may find after the build at `build/libs/qabel-core-x.y.z.jar` and `build/libs/qabel-box-x.y.z.jar`.
 
 Don't forget to include the `curve25519-linux-*.jar` (JNI) and the according libcurve implementation for your system (`build/binaries`).
 Qabel does a lot of crypto that is written in C and called via JNI. When launching your java application,

--- a/box/build.gradle
+++ b/box/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 sourceCompatibility = 1.8
-version = '0.1'
+version = '0.7.0'
 group = 'de.qabel.box'
 
 ext.sharedManifest = manifest {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'c'
 
 sourceCompatibility = 1.8
-version = '0.1'
+version = '0.7.0'
 group = 'de.qabel.core'
 
 jar {


### PR DESCRIPTION
the "current" tag is 0.6.0, 0.1 does not confirm to semver (which at least the clients mostly confirm to) and we have recently dropped compatibility to older versions by removing the persistence