### PR TITLE
resolves #494 pessimistic folder commit for conflict prevention

### DIFF
--- a/box/src/main/java/de/qabel/box/storage/AbstractMetadata.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractMetadata.kt
@@ -43,8 +43,9 @@ abstract class AbstractMetadata(val connection: ClientDatabase, path: File) {
     protected fun executeStatement(statementCallable: () -> PreparedStatement) {
         try {
             tryWith(statementCallable()) {
-                if (executeUpdate() != 1) {
-                    throw QblStorageException("Failed to execute statement")
+                val changedLines = executeUpdate()
+                if (changedLines != 1) {
+                    throw QblStorageException("Failed to execute statement, changedLines $changedLines != 1")
                 }
             }
         } catch (e: Exception) {

--- a/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
@@ -398,7 +398,7 @@ abstract class AbstractNavigation(
 
     @Synchronized @Throws(QblStorageException::class)
     override fun createFolder(name: String): BoxFolder {
-        execute(CreateFolderChange(name, folderNavigationFactory, directoryFactory)).boxObject
+        execute(CreateFolderChange(name, folderNavigationFactory, directoryFactory))
         commit()
         refresh()
         return getFolder(name)
@@ -409,7 +409,7 @@ abstract class AbstractNavigation(
 
     @Synchronized @Throws(QblStorageException::class)
     override fun unshare(boxObject: BoxObject) {
-        indexNavigation.getSharesOf(boxObject)?.forEach { share ->
+        indexNavigation.getSharesOf(boxObject).forEach { share ->
             try {
                 indexNavigation.deleteShare(share)
             } catch (e: QblStorageException) {

--- a/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
@@ -79,7 +79,6 @@ abstract class AbstractNavigation(
         }
     }
 
-
     @Synchronized @Throws(QblStorageException::class)
     override fun commitIfChanged() {
         if (isUnmodified) {
@@ -103,7 +102,7 @@ abstract class AbstractNavigation(
         }
 
         // the remote version has changed from the _old_ version
-        if (updatedDM != null && !Arrays.equals(version, updatedDM.version)) {
+        if (dm !== updatedDM && updatedDM != null && !Arrays.equals(version, updatedDM.version)) {
             logger.info("Conflicting version")
             // ignore our local directory metadata
             // all changes that are not inserted in the new dm are _lost_!
@@ -115,6 +114,11 @@ abstract class AbstractNavigation(
         changes.postprocess(dm, writeBackend)
 
         changes.clear()
+    }
+
+    @Synchronized @Throws(QblStorageException::class)
+    override fun refresh() {
+        dm = reloadMetadata().apply { changes.execute(this) }
     }
 
     override val isUnmodified: Boolean
@@ -392,10 +396,13 @@ abstract class AbstractNavigation(
         }
     }
 
-
     @Synchronized @Throws(QblStorageException::class)
-    override fun createFolder(name: String): BoxFolder
-        = execute(CreateFolderChange(name, folderNavigationFactory, directoryFactory)).boxObject
+    override fun createFolder(name: String): BoxFolder {
+        execute(CreateFolderChange(name, folderNavigationFactory, directoryFactory)).boxObject
+        commit()
+        refresh()
+        return getFolder(name)
+    }
 
     @Synchronized @Throws(QblStorageException::class)
     override fun delete(file: BoxFile) = execute(DeleteFileChange(file, indexNavigation, writeBackend))

--- a/box/src/main/java/de/qabel/box/storage/BoxNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/BoxNavigation.kt
@@ -10,6 +10,10 @@ import java.security.InvalidKeyException
 
 interface BoxNavigation : ReadableBoxNavigation {
 
+    /**
+     *  Fetches and returns the remote metadata file.
+     *  Does not update the internal metadata.
+     */
     @Throws(QblStorageException::class)
     fun reloadMetadata(): DirectoryMetadata
 
@@ -22,6 +26,13 @@ interface BoxNavigation : ReadableBoxNavigation {
      */
     @Throws(QblStorageException::class)
     fun commit()
+
+    /**
+     * Fetch the remote metadata, update the internal metadata with the newly fetched and apply pending changes to it.
+     * This is like a rebase to remote.
+     */
+    @Throws(QblStorageException::class)
+    fun refresh()
 
     /**
      * commits the DM if it has been changed (uploads or deletes)

--- a/box/src/main/java/de/qabel/box/storage/DefaultIndexNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/DefaultIndexNavigation.kt
@@ -16,8 +16,9 @@ class DefaultIndexNavigation(dm: DirectoryMetadata, val keyPair: QblECKeyPair, v
     private val directoryMetadataMHashes = WeakHashMap<Int, String>()
     private val logger by lazy { LoggerFactory.getLogger(DefaultIndexNavigation::class.java) }
     private val indexDmDownloader = object : IndexDMDownloader(readBackend, keyPair, tempDir, directoryFactory) {
-        override fun startDownload(rootRef: String)
-            = readBackend.download(rootRef, directoryMetadataMHashes[Arrays.hashCode(dm.version)])
+        override fun startDownload(rootRef: String): StorageDownload {
+            return readBackend.download(rootRef, directoryMetadataMHashes[Arrays.hashCode(dm.version)])
+        }
     }
 
     @Throws(QblStorageException::class)
@@ -25,7 +26,6 @@ class DefaultIndexNavigation(dm: DirectoryMetadata, val keyPair: QblECKeyPair, v
         val rootRef = dm.fileName
 
         try {
-
             val download = indexDmDownloader.loadDirectoryMetadata(rootRef)
             directoryMetadataMHashes.put(Arrays.hashCode(download.dm.version), download.etag)
             return download.dm

--- a/box/src/main/java/de/qabel/box/storage/LocalReadBackend.java
+++ b/box/src/main/java/de/qabel/box/storage/LocalReadBackend.java
@@ -2,6 +2,8 @@ package de.qabel.box.storage;
 
 import de.qabel.box.storage.exceptions.QblStorageException;
 import de.qabel.box.storage.exceptions.QblStorageNotFound;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +33,7 @@ public class LocalReadBackend implements StorageReadBackend {
         Path file = root.resolve(name);
 
         try {
-            if (ifModifiedVersion != null && String.valueOf(Files.getLastModifiedTime(file).toMillis()).equals(ifModifiedVersion)) {
+            if (ifModifiedVersion != null && getMHash(file).equals(ifModifiedVersion)) {
                 throw new UnmodifiedException();
             }
         } catch (IOException e) {
@@ -42,12 +44,17 @@ public class LocalReadBackend implements StorageReadBackend {
         try {
             return new StorageDownload(
                 Files.newInputStream(file),
-                String.valueOf(Files.getLastModifiedTime(file).toMillis()),
+                getMHash(file),
                 Files.size(file)
             );
         } catch (IOException e) {
             throw new QblStorageNotFound(e);
         }
+    }
+
+    @NotNull
+    private String getMHash(Path file) throws IOException {
+        return new String(DigestUtils.md5(Files.newInputStream(file)));
     }
 
     @Override

--- a/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadata.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadata.kt
@@ -128,7 +128,6 @@ class JdbcDirectoryMetadata(
 
         md.update(byteArrayOf(0, 1))
         md.update(oldVersion)
-        md.update(deviceId)
         md.update(UUID.randomUUID().toString().toByteArray())
         try {
             tryWith(connection.prepare("INSERT INTO version (version, time) VALUES (?, ?)")) {

--- a/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadata.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadata.kt
@@ -96,6 +96,7 @@ class JdbcDirectoryMetadata(
 
         md.update(byteArrayOf(0, 0))
         md.update(deviceId)
+        md.update(UUID.randomUUID().toString().toByteArray())
         return md.digest()
     }
 
@@ -128,6 +129,7 @@ class JdbcDirectoryMetadata(
         md.update(byteArrayOf(0, 1))
         md.update(oldVersion)
         md.update(deviceId)
+        md.update(UUID.randomUUID().toString().toByteArray())
         try {
             tryWith(connection.prepare("INSERT INTO version (version, time) VALUES (?, ?)")) {
                 setBytes(1, md.digest())
@@ -245,9 +247,13 @@ class JdbcDirectoryMetadata(
     }
 
     @Throws(QblStorageException::class)
-    override fun deleteFolder(folder: BoxFolder) = executeStatement {
-            connection.prepare("DELETE FROM folders WHERE name=?").apply{setString(1, folder.name)}
+    override fun deleteFolder(folder: BoxFolder) = try {
+        executeStatement {
+            connection.prepare("DELETE FROM folders WHERE name=?").apply { setString(1, folder.name) }
         }
+    } catch (e: QblStorageException) {
+        throw QblStorageException("failed to delete folder " + folder.name, e)
+    }
 
     @Throws(QblStorageException::class)
     override fun listFolders(): List<BoxFolder> {


### PR DESCRIPTION
according to #494 , the empty DM gets inserted to the parent-dm which is instantly uploaded, too, to make sure that if it is required to merge two newly created folders, they don't need to be merged because they latter one is empty.