### PR TITLE
Fix some Kotlin warnings

### DIFF
--- a/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
@@ -282,18 +282,18 @@ abstract class AbstractNavigation(
     override fun download(filename: String) = download(getFile(filename))
 
     @Throws(QblStorageException::class)
-    override fun download(boxFile: BoxFile) = download(boxFile, null)
+    override fun download(file: BoxFile) = download(file, null)
 
     @Throws(QblStorageException::class)
-    override fun download(boxFile: BoxFile, listener: ProgressListener?): InputStream {
+    override fun download(file: BoxFile, listener: ProgressListener?): InputStream {
         try {
-            readBackend.download("blocks/" + boxFile.block).use { download ->
+            readBackend.download("blocks/" + file.block).use { download ->
                 var content = download.inputStream
                 if (listener != null) {
                     listener.setSize(download.size)
                     content = ProgressInputStream(content, listener)
                 }
-                val key = KeyParameter(boxFile.getKey())
+                val key = KeyParameter(file.getKey())
                 val temp = File.createTempFile("upload", "down", tempDir)
                 temp.deleteOnExit()
                 if (!cryptoUtils.decryptFileAuthenticatedSymmetricAndValidateTag(content, temp, key)) {
@@ -520,8 +520,8 @@ abstract class AbstractNavigation(
     }
 
     @Throws(QblStorageException::class)
-    override fun getSharesOf(boxObject: BoxObject): List<BoxShare> {
-        return indexNavigation.listShares()?.filter({ share -> share.ref == boxObject.ref })?.toList()
+    override fun getSharesOf(`object`: BoxObject): List<BoxShare> {
+        return indexNavigation.listShares()?.filter({ share -> share.ref == `object`.ref })?.toList()
          ?: throw QblStorageException("No index navigation")
     }
 

--- a/box/src/main/java/de/qabel/box/storage/BoxNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/BoxNavigation.kt
@@ -246,10 +246,10 @@ interface BoxNavigation : ReadableBoxNavigation {
      * *
      * @param file     file to share
      * *
-     * @param receiver KeyId of the receivers (Contact) public key
+     * @param recipient KeyId of the recipients (Contact) public key
      */
     @Throws(QblStorageException::class)
-    fun share(owner: QblECPublicKey, file: BoxFile, receiver: String): BoxExternalReference
+    fun share(owner: QblECPublicKey, file: BoxFile, recipient: String): BoxExternalReference
 
     /**
      * List all created (and not yet deleted) shares for the given BoxObject

--- a/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataFactory.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataFactory.kt
@@ -41,7 +41,7 @@ class JdbcDirectoryMetadataFactory(val tempDir: File,
      * @param fileName  name of the file on the storage backend (remote ref)
      */
     override fun open(path: File, fileName: String): JdbcDirectoryMetadata {
-        return openDatabase(path, deviceId, fileName, tempDir)
+        return openDatabase(path, deviceId, fileName)
     }
 
 
@@ -53,11 +53,9 @@ class JdbcDirectoryMetadataFactory(val tempDir: File,
      * @param deviceId 16 random bytes that identify the current device
      * *
      * @param fileName name of the file on the storage backend
-     * *
-     * @param tempDir  writable temp directory
      */
     @Throws(QblStorageException::class)
-    private fun openDatabase(path: File, deviceId: ByteArray, fileName: String, tempDir: File): JdbcDirectoryMetadata {
+    private fun openDatabase(path: File, deviceId: ByteArray, fileName: String): JdbcDirectoryMetadata {
         try {
             val connection = DriverManager.getConnection(AbstractMetadata.JDBC_PREFIX + path.absolutePath)
             connection.autoCommit = true
@@ -89,7 +87,7 @@ class JdbcDirectoryMetadataFactory(val tempDir: File,
             throw QblStorageIOFailure(e)
         }
 
-        val dm = openDatabase(path, deviceId, UUID.randomUUID().toString(), tempDir)
+        val dm = openDatabase(path, deviceId, UUID.randomUUID().toString())
         try {
             initDatabase(dm)
             if (root != null) { dm.insertRoot(root) }

--- a/core/jni/scalarmult_test.c
+++ b/core/jni/scalarmult_test.c
@@ -18,7 +18,7 @@ unsigned char expectedpk[32] = {
 ,0xeb,0xa4,0xa9,0x8e,0xaa,0x9b,0x4e,0x6a
 };
 
-main()
+int main()
 {
   int i;
   crypto_scalarmult_base(alicepk,alicesk);

--- a/core/src/main/java/de/qabel/core/repository/sqlite/SqliteDropStateRepository.kt
+++ b/core/src/main/java/de/qabel/core/repository/sqlite/SqliteDropStateRepository.kt
@@ -12,7 +12,7 @@ class SqliteDropStateRepository(database: ClientDatabase,
                                 entityManager: EntityManager) :
     BaseRepositoryImpl<DropState>(DropStateDB, database, entityManager), DropStateRepository {
 
-    override fun getDropState(dropId: String) = findByDropId(dropId).eTag
+    override fun getDropState(drop: String) = findByDropId(drop).eTag
 
     private fun findByDropId(dropId: String): DropState =
         with(createEntityQuery()) {
@@ -20,14 +20,14 @@ class SqliteDropStateRepository(database: ClientDatabase,
             return getSingleResult<DropState>(this)
         }
 
-    override fun setDropState(dropId: String, state: String): Unit =
+    override fun setDropState(drop: String, state: String): Unit =
         try {
-            findByDropId(dropId).let {
+            findByDropId(drop).let {
                 it.eTag = state
                 update(it)
             }
         } catch(ex: EntityNotFoundException) {
-            DropState(dropId, state).let { persist(it) }
+            DropState(drop, state).let { persist(it) }
         }
 
     override fun getDropState(dropUrl: DropURL): DropState =


### PR DESCRIPTION
The remaining warnings are deprecation warnings, one unused variable that improves readability, and a parameter that will be used in the future:

```
w: /home/mabe/Projekte/_qabel/core/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt: (44, 35): 'DEFAULT_AUTOCOMMIT_DELAY: Long' is deprecated.
w: /home/mabe/Projekte/_qabel/core/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt: (172, 54): Parameter 'expectedFile' is never used
w: /home/mabe/Projekte/_qabel/core/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt: (206, 17): 'updateFileMetadata(BoxFile): Unit' is deprecated. Overrides deprecated member in 'de.qabeavigation'. should only be called internally (on update)
w: /home/mabe/Projekte/_qabel/core/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt: (516, 19): 'createFileMetadata(QblECPublicKey, BoxFile): BoxExternalReference' is deprecated. Overrider in 'de.qabel.box.storage.BoxNavigation'. should only be called internally (to ensure an index entry)
w: /home/mabe/Projekte/_qabel/core/box/src/main/java/de/qabel/box/storage/BoxVolumeImpl.kt: (75, 62): 'rootRef: String' is deprecated. Overrides deprecated member in 'de.qabel.box.storage.BoxVolume'n
w: /home/mabe/Projekte/_qabel/core/box/src/main/java/de/qabel/box/storage/BoxVolumeImpl.kt: (109, 40): 'rootRef: String' is deprecated. Overrides deprecated member in 'de.qabel.box.storage.BoxVolumeon

w: /home/mabe/Projekte/_qabel/core/core/src/main/java/de/qabel/core/contacts/ContactExchangeFormats.kt: (116, 14): Variable 'ignoredPrefix' is never used
w: /home/mabe/Projekte/_qabel/core/core/src/main/java/de/qabel/core/repository/framework/BaseRepositoryImpl.kt: (62, 39): Unchecked cast: DBRelation<T#1 (type parameter of de.qabel.core.repository.framework.BaseRepositoryImpl)> to ResultAdapter<T#2 (type parameter of de.qabel.core.repository.framework.BaseRepositoryImpl.getSingleResult)>
w: /home/mabe/Projekte/_qabel/core/core/src/main/java/de/qabel/core/repository/framework/BaseRepositoryImpl.kt: (74, 37): Unchecked cast: DBRelation<T#1 (type parameter of de.qabel.core.repository.framework.BaseRepositoryImpl)> to ResultAdapter<T#2 (type parameter of de.qabel.core.repository.framework.BaseRepositoryImpl.getResultList)>
w: /home/mabe/Projekte/_qabel/core/core/src/main/java/de/qabel/core/repository/sqlite/SqliteDropUrlRepository.kt: (31, 16): 'findAll(Int): Collection<DropURL>' is deprecated. @todo hide contactId and use findAll(Contact contact) as soon as Identity extends Contact
w: /home/mabe/Projekte/_qabel/core/core/src/main/java/de/qabel/core/repository/sqlite/SqliteDropUrlRepository.kt: (37, 9): 'delete(Int): Unit' is deprecated. @todo hide contactId and use delete(Contact contact) as soon as Identity extends Contact
w: /home/mabe/Projekte/_qabel/core/core/src/main/java/de/qabel/core/repository/sqlite/SqliteDropUrlRepository.kt: (54, 9): 'store(Entity, Int): Unit' is deprecated. @todo hide contactId and use store(Contact contact) as soon as Identity extends Contact
```

The two casts can't be fixed at this time I think.