### PR TITLE
Multijar

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Qabel consists of multiple Projects:
 Distributions of the Clients are provided by the [official Qabel website](https://qabel.de) at https://qabel.de/de/download .
 Everything below this line describes the usage of the Qabel Core Library for development purposes.
 
+To use the Qabel Core as a library with gradle, add the following to your build.gradle:
+```GRADLE
+repositories {
+    maven { url "https://jitpack.io" }
+}
+dependencies {
+    compile 'com.github.Qabel.qabel-core:core:0.16.1'
+    compile 'com.github.Qabel.qabel-core:box:0.16.1'
+}
+```
+replace `0.16.1` with the latest release from https://jitpack.io/#Qabel/qabel-core
+
 # <a name="getting_started"></a>Getting started
 
 For a reference build, the core provides a `Vagrantfile` that sets up all requirements and can do a full build.

--- a/box/build.gradle
+++ b/box/build.gradle
@@ -1,25 +1,6 @@
-apply plugin: 'java'
-apply plugin: "kotlin"
-
-sourceCompatibility = 1.7
-version = '0.16.1'
 group = 'de.qabel.box'
 
-ext.sharedManifest = manifest {
-    attributes 'Implementation-Version': version
-    attributes 'Project': 'Qabel Core'
-    attributes 'Component': 'Box'
-    attributes 'Built-From-Revision': "git rev-parse HEAD".execute().text.trim()
-}
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
+ext.sharedManifest.attributes 'Component': 'Box'
 
 jar {
     manifest = project.manifest {
@@ -33,43 +14,12 @@ repositories {
 }
 
 dependencies {
-	testCompile group: 'junit', name: 'junit', version: '4.+'
-	testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
-	testCompile group: 'org.meanbean', name: 'meanbean', version: '2.+'
 	compile project(':core')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 tasks.withType(Test) {
 	def platform = "${System.properties['os.name'].toLowerCase()}_${System.properties['os.arch']}"
 	systemProperty "java.library.path", "../core/build/binaries/curve25519SharedLibrary/$platform/"
 }
+testJar.manifest.attributes 'Implementation-Title': 'Qabel Core - Box Component - Test artifact'
 
-sourceSets {
-	main {
-		resources.srcDirs += ['src/resources/config/']
-	}
-	test {
-		resources.srcDirs += ['src/resources/config/']
-	}
-}
-
-task testJar(type: Jar) {
-    from(sourceSets.test.output) {
-        include "**"
-    }
-    baseName = 'box-test'
-    manifest {
-        from sharedManifest
-        attributes 'Implementation-Title': 'Qabel Core - Box Component - Test artifact'
-    }
-}
-
-jar.manifest.writeTo("$buildDir/manifest.mf")
-testJar.manifest.writeTo("$buildDir/test-manifest.mf")
-jar.dependsOn(testJar)
-
-artifacts {
-    archives jar
-    //archives testJar
-}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,9 @@ buildscript {
 }
 
 allprojects {
-    version = '0.16.2'
+    String tag ='git describe --tags'.execute().text.trim()
+    Boolean isTag = !tag.contains('-')
+    version = isTag ? tag : 'git rev-parse HEAD'.execute().text.trim() + '-SNAPSHOT'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,66 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     ext.kotlin_version = '1.0.2'
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    version = '0.16.2'
+}
+
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'kotlin'
+
+    sourceCompatibility = 1.7
+
+    ext.sharedManifest = manifest {
+        attributes 'Implementation-Version': version
+        attributes 'Project': 'Qabel Core'
+        attributes 'Built-From-Revision': "git rev-parse HEAD".execute().text.trim()
+    }
+
+    dependencies {
+        testCompile group: 'junit', name: 'junit', version: '4.+'
+        testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
+        testCompile group: 'org.meanbean', name: 'meanbean', version: '2.+'
+        compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource + sourceSets.test.allSource
+    }
+
+    task testJar(type: Jar) {
+        classifier = 'tests'
+        from(sourceSets.test.output) {
+            include "**"
+        }
+        manifest {
+            from sharedManifest
+            attributes 'Implementation-Title': 'Qabel Core - Test artifact'
+        }
+    }
+
+    sourceSets {
+        main {
+            resources.srcDirs += ['src/resources/config/']
+        }
+        test {
+            resources.srcDirs += ['src/resources/config/']
+        }
+    }
+
+    jar.manifest.writeTo("$buildDir/manifest.mf")
+    testJar.manifest.writeTo("$buildDir/test-manifest.mf")
+
+    artifacts {
+        archives sourcesJar
+        archives testJar
+    }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,27 +1,8 @@
-apply plugin: 'java'
 apply plugin: 'c'
-apply plugin: "kotlin"
 
-sourceCompatibility = 1.7
-version = '0.16.1'
 group = 'de.qabel.core'
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-
-ext.sharedManifest = manifest {
-    attributes 'Implementation-Version': version
-    attributes 'Project': 'Qabel Core'
-    attributes 'Component': 'Core'
-    attributes 'Built-From-Revision': "git rev-parse HEAD".execute().text.trim()
-}
+ext.sharedManifest.attributes 'Component': 'Core'
 
 jar {
     manifest = project.manifest {
@@ -35,9 +16,6 @@ repositories {
 }
 
 dependencies {
-	testCompile group: 'junit', name: 'junit', version: '4.+'
-	testCompile group: 'org.meanbean', name: 'meanbean', version: '2.+'
-    testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
 	compile 'com.google.code.gson:gson:2.+'
 	compile 'com.github.salomonbrys.kotson:kotson:2.3.0'
 	compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'
@@ -50,7 +28,6 @@ dependencies {
 	compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.8.7'
 	compile 'com.madgag.spongycastle:prov:1.53.0.0'
 	compile 'org.json:json:20160212'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 task nativeHeaders {
@@ -166,26 +143,4 @@ tasks.withType(Test) {
 	systemProperty "java.library.path", "./build/binaries/curve25519SharedLibrary/$platform/"
 }
 
-sourceSets {
-	main {
-		resources.srcDirs += ['src/resources/config/']
-	}
-	test {
-		resources.srcDirs += ['src/resources/config/']
-	}
-}
-
-task testJar(type: Jar) {
-    from(sourceSets.test.output) {
-        include "**"
-    }
-    baseName = 'core-test'
-    manifest {
-        from sharedManifest
-        attributes 'Implementation-Title': 'Qabel Core - Box Component - Test artifact'
-    }
-}
-
-jar.manifest.writeTo("$buildDir/manifest.mf")
-testJar.manifest.writeTo("$buildDir/test-manifest.mf")
-jar.dependsOn(testJar)
+testJar.manifest.attributes 'Implementation-Title': 'Qabel Core - Core Component - Test artifact'


### PR DESCRIPTION
fixes the artifact mess
+the version is set automatically (the tag if it is a tag, <commit-hash>-SNAPSHOT if it isn't a tag)

Use like this:
```GRADLE
    compile 'com.github.Qabel.qabel-core:core:0.16.2'
    compile 'com.github.Qabel.qabel-core:box:0.16.2'

    testCompile 'com.github.Qabel.qabel-core:box:0.16.2:tests'
    testCompile 'com.github.Qabel.qabel-core:box:0.16.2:sources'
    testCompile 'com.github.Qabel.qabel-core:core:0.16.2:tests'
    testCompile 'com.github.Qabel.qabel-core:core:0.16.2:sources'
```

it's `group`=repo, `artifact`=module, `version`=tag, `classifier`='' or 'tests' or 'sources'.
Maybe using the idea-gradle-plugin, one could omit the sources artifacts but that's up to the clients.

JitPack builds like [this](https://jitpack.io/com/github/julianseeger/qabel-core/ec1c021998ec75e6d13b883692be6096b8b4712d/build.log): 

```

Build artifacts:
com.github.julianseeger.qabel-core:box:ec1c021998ec75e6d13b883692be6096b8b4712d
com.github.julianseeger.qabel-core:core:ec1c021998ec75e6d13b883692be6096b8b4712d

Files: 
com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d
com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d/box-ec1c021998ec75e6d13b883692be6096b8b4712d-sources.jar
com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d/box-ec1c021998ec75e6d13b883692be6096b8b4712d-tests.jar
com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d/box-ec1c021998ec75e6d13b883692be6096b8b4712d.jar
com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d/box-ec1c021998ec75e6d13b883692be6096b8b4712d.pom
com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d/box-ec1c021998ec75e6d13b883692be6096b8b4712d.pom.md5
com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d/box-ec1c021998ec75e6d13b883692be6096b8b4712d.pom.sha1

com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d
com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d/core-ec1c021998ec75e6d13b883692be6096b8b4712d-sources.jar
com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d/core-ec1c021998ec75e6d13b883692be6096b8b4712d-tests.jar
com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d/core-ec1c021998ec75e6d13b883692be6096b8b4712d.jar
com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d/core-ec1c021998ec75e6d13b883692be6096b8b4712d.pom
com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d/core-ec1c021998ec75e6d13b883692be6096b8b4712d.pom.md5
com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d/core-ec1c021998ec75e6d13b883692be6096b8b4712d.pom.sha1
```
resulting in the two module dirs:
https://jitpack.io/com/github/julianseeger/qabel-core/box/ec1c021998ec75e6d13b883692be6096b8b4712d/
https://jitpack.io/com/github/julianseeger/qabel-core/core/ec1c021998ec75e6d13b883692be6096b8b4712d/