### PR TITLE
Delete the block in postprocess

### DIFF
--- a/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
@@ -199,7 +199,7 @@ abstract class AbstractNavigation(
         val uploadResult = uploadEncrypted(fileInput, key, "blocks/" + block, listener)
         boxFile.hashed = uploadResult.hash
 
-        execute(UpdateFileChange(oldFile, boxFile, writeBackend))
+        execute(UpdateFileChange(oldFile, boxFile))
 
         try {
             if (boxFile.isShared()) {

--- a/box/src/main/java/de/qabel/box/storage/command/DirectoryMetadataChange.kt
+++ b/box/src/main/java/de/qabel/box/storage/command/DirectoryMetadataChange.kt
@@ -3,6 +3,10 @@ package de.qabel.box.storage.command
 import de.qabel.box.storage.DirectoryMetadata
 import de.qabel.box.storage.exceptions.QblStorageException
 
+/**
+ * If your change needs to be followed by a non-reversible action (like deleting a file on the block server),
+ * let your change operation also implement Postprocessable
+ */
 interface DirectoryMetadataChange<T> {
     @Throws(QblStorageException::class)
     fun execute(dm: DirectoryMetadata): T

--- a/box/src/test/java/de/qabel/box/storage/command/UpdateFileChangeTest.kt
+++ b/box/src/test/java/de/qabel/box/storage/command/UpdateFileChangeTest.kt
@@ -77,8 +77,12 @@ class UpdateFileChangeTest {
                 deleted = name!!
             }
         }
-        UpdateFileChange(null, hashedFile, backend).execute(dm)
+        val change = UpdateFileChange(null, hashedFile, backend)
+        change.execute(dm)
         assertEquals("Block was not deleted", "blocks/" + hashedFile.block, deleted)
+        deleted = ""
+        change.execute(dm)
+        assertEquals("Block was deleted twice", "blocks/" + hashedFile.block, deleted)
 
         assertThat(dm.listFiles(), allOf(containsInAnyOrder(hashedFile), hasSize(1)))
         assertThat(hashedFile.name, equalTo("filename"))


### PR DESCRIPTION
Fixup for concerns raised in https://github.com/Qabel/qabel-core/pull/568