### PR TITLE
Force commit of index navigation after sharing

### DIFF
--- a/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
@@ -135,23 +135,6 @@ abstract class AbstractNavigation(
     }
 
     @Throws(QblStorageException::class)
-    fun listShares(): List<BoxShare> = dm.listShares()
-
-    @Throws(QblStorageException::class)
-    fun insertShare(share: BoxShare): Unit {
-        execute(InsertShareChange(share))
-        // forcing a commit because these changes are needed even when autocommit is disabled
-        commit()
-    }
-
-    @Throws(QblStorageException::class)
-    fun deleteShare(share: BoxShare): Unit {
-        execute(DeleteShareChange(share))
-        // forcing a commit because these changes are needed even when autocommit is disabled
-        commit()
-    }
-
-    @Throws(QblStorageException::class)
     override fun listFolders(): List<BoxFolder> = dm.listFolders()
 
     @Throws(QblStorageException::class)
@@ -458,7 +441,7 @@ abstract class AbstractNavigation(
         execute(DeleteFolderChange(folder))
     }
 
-    private fun <T> execute(command: DirectoryMetadataChange<T>): T {
+    protected fun <T> execute(command: DirectoryMetadataChange<T>): T {
         val result = command.execute(dm)
         changes.add(command)
         autocommit()

--- a/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractNavigation.kt
@@ -138,10 +138,18 @@ abstract class AbstractNavigation(
     fun listShares(): List<BoxShare> = dm.listShares()
 
     @Throws(QblStorageException::class)
-    fun insertShare(share: BoxShare): Unit = execute(InsertShareChange(share))
+    fun insertShare(share: BoxShare): Unit {
+        execute(InsertShareChange(share))
+        // forcing a commit because these changes are needed even when autocommit is disabled
+        commit()
+    }
 
     @Throws(QblStorageException::class)
-    fun deleteShare(share: BoxShare): Unit = execute(DeleteShareChange(share))
+    fun deleteShare(share: BoxShare): Unit {
+        execute(DeleteShareChange(share))
+        // forcing a commit because these changes are needed even when autocommit is disabled
+        commit()
+    }
 
     @Throws(QblStorageException::class)
     override fun listFolders(): List<BoxFolder> = dm.listFolders()

--- a/box/src/main/java/de/qabel/box/storage/DefaultIndexNavigation.kt
+++ b/box/src/main/java/de/qabel/box/storage/DefaultIndexNavigation.kt
@@ -1,5 +1,7 @@
 package de.qabel.box.storage
 
+import de.qabel.box.storage.command.DeleteShareChange
+import de.qabel.box.storage.command.InsertShareChange
 import de.qabel.box.storage.exceptions.QblStorageException
 import de.qabel.core.crypto.QblECKeyPair
 import org.apache.commons.io.IOUtils
@@ -53,6 +55,23 @@ class DefaultIndexNavigation(dm: DirectoryMetadata, val keyPair: QblECKeyPair, v
             throw QblStorageException(e)
         }
 
+    }
+
+    @Throws(QblStorageException::class)
+    override fun listShares(): List<BoxShare> = dm.listShares()
+
+    @Throws(QblStorageException::class)
+    override fun insertShare(share: BoxShare): Unit {
+        execute(InsertShareChange(share))
+        // forcing a commit because these changes are needed even when autocommit is disabled
+        commit()
+    }
+
+    @Throws(QblStorageException::class)
+    override fun deleteShare(share: BoxShare): Unit {
+        execute(DeleteShareChange(share))
+        // forcing a commit because these changes are needed even when autocommit is disabled
+        commit()
     }
 
     override val indexNavigation = this

--- a/box/src/test/java/de/qabel/box/storage/BoxVolumeTest.java
+++ b/box/src/test/java/de/qabel/box/storage/BoxVolumeTest.java
@@ -708,6 +708,22 @@ public abstract class BoxVolumeTest {
         assertThat(subnavB2.listFiles(), hasSize(1));
     }
 
+    @Test
+    public void shareInsertedInIndexNavigationWhenSharingFromFolder() throws Exception {
+        BoxNavigation nav = volume.navigate();
+        nav.setAutocommit(false);
+        BoxFolder folder = nav.createFolder("folder");
+        BoxNavigation subNav = nav.navigate(folder);
+        File file = new File(testFileName);
+        BoxFile boxFile = subNav.upload("file1", file);
+        subNav.share(keyPair.getPub(), boxFile, contact.getKeyIdentifier());
+        subNav.commit();
+
+        BoxNavigation nav2 = volume2.navigate().navigate("folder");
+        assertThat(nav2.getSharesOf(nav2.getFile("file1")), hasSize(1));
+
+    }
+
     protected boolean blockExists(String meta) throws QblStorageException {
         try {
             getReadBackend().download(meta);


### PR DESCRIPTION
Autocommit mitigated most of the problem, but only if
another change like creating a folder happened. Just sharing a
file from the subfolder did not force a commit in the index navigation
Fixes #543