### PR TITLE
Test for upgrading from old versions

### DIFF
--- a/box/src/main/java/de/qabel/box/storage/jdbc/migration/DMMigration1467796453Init.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/migration/DMMigration1467796453Init.kt
@@ -7,20 +7,20 @@ class DMMigration1467796453Init(connection : Connection) : AbstractMigration(con
     override fun getVersion() = 1467796453L
 
     override fun up() {
-        execute("""CREATE TABLE meta (
+        execute("""CREATE TABLE IF NOT EXISTS meta (
                 name VARCHAR(24) PRIMARY KEY,
                 value TEXT )""")
-        execute("CREATE TABLE spec_version (version INTEGER PRIMARY KEY )")
-        execute("""CREATE TABLE version (
+        execute("CREATE TABLE IF NOT EXISTS spec_version (version INTEGER PRIMARY KEY )")
+        execute("""CREATE TABLE IF NOT EXISTS version (
                 id INTEGER PRIMARY KEY,
                 version BLOB NOT NULL,
                 time LONG NOT NULL )""")
-        execute("""CREATE TABLE shares (
+        execute("""CREATE TABLE IF NOT EXISTS shares (
                 ref VARCHAR(255)NOT NULL,
                 recipient BLOB NOT NULL,
                 type INTEGER NOT NULL )""")
-        execute("CREATE UNIQUE INDEX uniqueShares ON shares(ref, recipient, type)")
-        execute("""CREATE TABLE files (
+        execute("CREATE UNIQUE INDEX IF NOT EXISTS uniqueShares ON shares(ref, recipient, type)")
+        execute("""CREATE TABLE IF NOT EXISTS files (
                 prefix VARCHAR(255)NOT NULL,
                 block VARCHAR(255)NOT NULL,
                 name VARCHAR(255)NOT NULL PRIMARY KEY,
@@ -29,17 +29,17 @@ class DMMigration1467796453Init(connection : Connection) : AbstractMigration(con
                 key BLOB NOT NULL,
                 meta VARCAHR(255),
                 metakey BLOB)""")
-        execute("""CREATE TABLE folders (
+        execute("""CREATE TABLE IF NOT EXISTS folders (
                 ref VARCHAR(255)NOT NULL,
                 name VARCHAR(255)NOT NULL PRIMARY KEY,
                 key BLOB NOT NULL )""")
-        execute("""CREATE TABLE externals (
+        execute("""CREATE TABLE IF NOT EXISTS externals (
                 is_folder BOOLEAN NOT NULL,
                 owner BLOB NOT NULL,
                 name VARCHAR(255)NOT NULL PRIMARY KEY,
                 key BLOB NOT NULL,
                 url TEXT NOT NULL )""")
-        execute("INSERT INTO spec_version (version) VALUES(0)")
+        execute("INSERT OR IGNORE INTO spec_version (version) VALUES(0)")
     }
 
     override fun down() {

--- a/box/src/test/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataTest.kt
+++ b/box/src/test/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataTest.kt
@@ -125,4 +125,11 @@ class JdbcDirectoryMetadataTest {
         val loadedFile = dm.getFile("n")!!
         assertTrue(loadedFile.isHashed())
     }
+
+    @Test
+    fun migratioFrom0Version() {
+        dm.connection.version = 0
+        dm.connection.migrate()
+        assertNotEquals(0, dm.connection.version)
+    }
 }

--- a/box/src/test/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataTest.kt
+++ b/box/src/test/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataTest.kt
@@ -5,6 +5,7 @@ import de.qabel.box.storage.BoxFolder
 import de.qabel.box.storage.BoxShare
 import de.qabel.box.storage.Hash
 import de.qabel.box.storage.exceptions.QblStorageException
+import de.qabel.box.storage.jdbc.migration.DMMigration1468245565Hash
 import org.hamcrest.CoreMatchers.*
 import org.junit.Assert.*
 import org.junit.Test
@@ -129,7 +130,10 @@ class JdbcDirectoryMetadataTest {
     @Test
     fun migratioFrom0Version() {
         dm.connection.version = 0
-        dm.connection.migrate()
+        // Only that migration needs to be tested because
+        // that is the schema out there with version = 0
+        dm.connection.migrateTo(1467796453L)
+        // the migration should run as a noop, except that now a version is set.
         assertNotEquals(0, dm.connection.version)
     }
 }


### PR DESCRIPTION
The published release doesn't set a user_version, so any existing DMs will be migrated which crashes because the tables already exist.

See https://github.com/Qabel/qabel-android/issues/646