### PR TITLE
Inject jdbc prefix into factories

### DIFF
--- a/box/src/main/java/de/qabel/box/storage/AbstractMetadata.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractMetadata.kt
@@ -55,6 +55,8 @@ abstract class AbstractMetadata(val connection: ClientDatabase, path: File) {
 
     companion object {
         val TYPE_NONE = -1
+        @JvmField
+        val DEFAULT_JDBC_PREFIX: String = "jdbc:sqlite:"
     }
 }
 

--- a/box/src/main/java/de/qabel/box/storage/AbstractMetadata.kt
+++ b/box/src/main/java/de/qabel/box/storage/AbstractMetadata.kt
@@ -55,8 +55,6 @@ abstract class AbstractMetadata(val connection: ClientDatabase, path: File) {
 
     companion object {
         val TYPE_NONE = -1
-        @JvmField
-        val JDBC_PREFIX = "jdbc:sqlite:"
     }
 }
 

--- a/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataFactory.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataFactory.kt
@@ -1,6 +1,5 @@
 package de.qabel.box.storage.jdbc
 
-import de.qabel.box.storage.AbstractMetadata
 import de.qabel.box.storage.DirectoryMetadataFactory
 import de.qabel.box.storage.exceptions.QblStorageCorruptMetadata
 import de.qabel.box.storage.exceptions.QblStorageException
@@ -16,8 +15,10 @@ import java.util.*
 class JdbcDirectoryMetadataFactory(val tempDir: File,
                                    val deviceId: ByteArray,
                                    private val dataBaseFactory: (Connection) -> DirectoryMetadataDatabase =
-                                       { DirectoryMetadataDatabase(it) }
+                                       { DirectoryMetadataDatabase(it) },
+                                   val jdbcPrefix: String = "jdbc:sqlite:"
                                    ) : DirectoryMetadataFactory {
+
     /**
      * Create (and init) a new Index DM including a new database file
      *
@@ -57,7 +58,7 @@ class JdbcDirectoryMetadataFactory(val tempDir: File,
     @Throws(QblStorageException::class)
     private fun openDatabase(path: File, deviceId: ByteArray, fileName: String): JdbcDirectoryMetadata {
         try {
-            val connection = DriverManager.getConnection(AbstractMetadata.JDBC_PREFIX + path.absolutePath)
+            val connection = DriverManager.getConnection(jdbcPrefix + path.absolutePath)
             connection.autoCommit = true
             tryWith(connection.createStatement()) { execute("PRAGMA journal_mode=MEMORY") }
             val db = dataBaseFactory(connection)

--- a/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataFactory.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/JdbcDirectoryMetadataFactory.kt
@@ -1,5 +1,6 @@
 package de.qabel.box.storage.jdbc
 
+import de.qabel.box.storage.AbstractMetadata
 import de.qabel.box.storage.DirectoryMetadataFactory
 import de.qabel.box.storage.exceptions.QblStorageCorruptMetadata
 import de.qabel.box.storage.exceptions.QblStorageException
@@ -16,7 +17,7 @@ class JdbcDirectoryMetadataFactory(val tempDir: File,
                                    val deviceId: ByteArray,
                                    private val dataBaseFactory: (Connection) -> DirectoryMetadataDatabase =
                                        { DirectoryMetadataDatabase(it) },
-                                   val jdbcPrefix: String = "jdbc:sqlite:"
+                                   val jdbcPrefix: String = AbstractMetadata.DEFAULT_JDBC_PREFIX
                                    ) : DirectoryMetadataFactory {
 
     /**

--- a/box/src/main/java/de/qabel/box/storage/jdbc/JdbcFileMetadataFactory.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/JdbcFileMetadataFactory.kt
@@ -1,11 +1,9 @@
 package de.qabel.box.storage.jdbc
 
-import de.qabel.box.storage.AbstractMetadata
 import de.qabel.box.storage.BoxFile
 import de.qabel.box.storage.FileMetadataFactory
 import de.qabel.box.storage.exceptions.QblStorageException
 import de.qabel.core.crypto.QblECPublicKey
-import de.qabel.core.repository.sqlite.PragmaVersion
 import de.qabel.core.repository.sqlite.PragmaVersionAdapter
 import de.qabel.core.repository.sqlite.VersionAdapter
 import java.io.File
@@ -16,8 +14,10 @@ import java.sql.SQLException
 
 class JdbcFileMetadataFactory @JvmOverloads constructor(
     val tmpDir: File,
-    var versionAdapterFactory : (connection : Connection) -> VersionAdapter = { PragmaVersionAdapter(it)}
+    var versionAdapterFactory : (connection : Connection) -> VersionAdapter = { PragmaVersionAdapter(it)},
+    val jdbcPrefix: String = "jdbc:sqlite:"
 ) : FileMetadataFactory {
+
 
 
     @Throws(QblStorageException::class)
@@ -27,7 +27,7 @@ class JdbcFileMetadataFactory @JvmOverloads constructor(
 
     private fun openExisting(path: File): JdbcFileMetadata {
         try {
-            val connection = DriverManager.getConnection(AbstractMetadata.JDBC_PREFIX + path.absolutePath)
+            val connection = DriverManager.getConnection(jdbcPrefix+ path.absolutePath)
             connection.autoCommit = true
             val db = FileMetadataDatabase(connection, versionAdapterFactory.invoke(connection))
             db.migrate()
@@ -42,7 +42,7 @@ class JdbcFileMetadataFactory @JvmOverloads constructor(
         try {
             val path = File.createTempFile("dir", "db6", tmpDir)
 
-            val connection = DriverManager.getConnection(AbstractMetadata.JDBC_PREFIX + path.absolutePath)
+            val connection = DriverManager.getConnection(jdbcPrefix + path.absolutePath)
             connection.autoCommit = true
             val db = FileMetadataDatabase(connection, versionAdapterFactory.invoke(connection))
             db.migrate()

--- a/box/src/main/java/de/qabel/box/storage/jdbc/JdbcFileMetadataFactory.kt
+++ b/box/src/main/java/de/qabel/box/storage/jdbc/JdbcFileMetadataFactory.kt
@@ -1,5 +1,6 @@
 package de.qabel.box.storage.jdbc
 
+import de.qabel.box.storage.AbstractMetadata
 import de.qabel.box.storage.BoxFile
 import de.qabel.box.storage.FileMetadataFactory
 import de.qabel.box.storage.exceptions.QblStorageException
@@ -15,7 +16,7 @@ import java.sql.SQLException
 class JdbcFileMetadataFactory @JvmOverloads constructor(
     val tmpDir: File,
     var versionAdapterFactory : (connection : Connection) -> VersionAdapter = { PragmaVersionAdapter(it)},
-    val jdbcPrefix: String = "jdbc:sqlite:"
+    val jdbcPrefix: String = AbstractMetadata.DEFAULT_JDBC_PREFIX
 ) : FileMetadataFactory {
 
 


### PR DESCRIPTION
Required for https://github.com/Qabel/qabel-android/issues/713 Otherwise the android system tries to load the native jdbc driver which is not available on android 7.