### PR TITLE
casted, filtered event streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.26.2 - 2016-10-30
+### CHANGED
+- (BC break) EventSource.events is now a property and events() infers type
+
 ## 0.26.0 - 2016-10-24
 ### ADDED
 - metaVolumes (for cross client sync) #496

--- a/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
+++ b/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
@@ -5,7 +5,7 @@ import rx.Observable
 interface EventSource {
     fun events(): Observable<Event>
     fun <T : Event> events(type: Class<T>): Observable<T>
-        = events().filter { type.isInstance(it) }.map { type.cast(it) }
+        = events().ofType(type).map { type.cast(it) }
 }
 interface EventSink {
     fun push(event: Event)

--- a/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
+++ b/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
@@ -5,7 +5,7 @@ import rx.Observable
 interface EventSource {
     fun events(): Observable<Event>
     fun <T : Event> events(type: Class<T>): Observable<T>
-        = events().ofType(type).map { type.cast(it) }
+        = events().ofType(type)
 }
 interface EventSink {
     fun push(event: Event)

--- a/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
+++ b/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
@@ -3,11 +3,11 @@ package de.qabel.core.event
 import rx.Observable
 
 interface EventSource {
-    fun events(): Observable<Event>
-    fun <T : Event> events(type: Class<T>): Observable<T>
-        = events().ofType(type)
+    val events: Observable<Event>
+    fun <T : Event> events(type: Class<T>): Observable<T> = events.ofType(type)
 }
 interface EventSink {
     fun push(event: Event)
 }
 interface EventDispatcher: EventSource, EventSink
+inline fun <reified T : Event> EventSource.events(): Observable<T> = events.ofType(T::class.java)

--- a/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
+++ b/core/src/main/java/de/qabel/core/event/EventDispatcher.kt
@@ -4,6 +4,8 @@ import rx.Observable
 
 interface EventSource {
     fun events(): Observable<Event>
+    fun <T : Event> events(type: Class<T>): Observable<T>
+        = events().filter { type.isInstance(it) }.map { type.cast(it) }
 }
 interface EventSink {
     fun push(event: Event)

--- a/core/src/main/java/de/qabel/core/event/SubjectEventDispatcher.kt
+++ b/core/src/main/java/de/qabel/core/event/SubjectEventDispatcher.kt
@@ -1,17 +1,12 @@
 package de.qabel.core.event
 
-import rx.Observable
 import rx.subjects.PublishSubject
 import rx.subjects.SerializedSubject
 
 class SubjectEventDispatcher : EventDispatcher {
-    private val subject = SerializedSubject(PublishSubject.create<Event>())
-
-    override fun events(): Observable<Event> {
-        return subject
-    }
+    override val events = SerializedSubject(PublishSubject.create<Event>())
 
     override fun push(event: Event) {
-        subject.onNext(event)
+        events.onNext(event)
     }
 }

--- a/core/src/test/java/de/qabel/core/event/SubjectEventDispatcherTest.kt
+++ b/core/src/test/java/de/qabel/core/event/SubjectEventDispatcherTest.kt
@@ -4,14 +4,15 @@ import de.qabel.core.extensions.letApply
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Test
+import rx.Observable
 import rx.observers.TestSubscriber
 
 class SubjectEventDispatcherTest {
+    val dispatcher = SubjectEventDispatcher()
+    val testsubscriber = TestSubscriber<Event>()
+
     @Test
     fun providesFilteredEventStream() {
-        val dispatcher = SubjectEventDispatcher()
-        val testsubscriber = TestSubscriber<Event>()
-
         dispatcher.events(TestEventA::class.java).subscribe(testsubscriber)
         dispatcher.push(TestEventB())
         val eventA: TestEventA = TestEventA().letApply { dispatcher.push(it) }
@@ -19,7 +20,18 @@ class SubjectEventDispatcherTest {
         val onNextEvents = testsubscriber.onNextEvents
         assertEquals(1, onNextEvents.size)
         assertSame(eventA, onNextEvents.first())
+    }
 
+    @Test
+    fun providesFilteredEventStreamByTypeInference() {
+        val events: Observable<TestEventA> = dispatcher.events()
+        events.subscribe(testsubscriber)
+        dispatcher.push(TestEventB())
+        val eventA: TestEventA = TestEventA().letApply { dispatcher.push(it) }
+
+        val onNextEvents = testsubscriber.onNextEvents
+        assertEquals(1, onNextEvents.size)
+        assertSame(eventA, onNextEvents.first())
     }
 }
 class TestEventA : Event

--- a/core/src/test/java/de/qabel/core/event/SubjectEventDispatcherTest.kt
+++ b/core/src/test/java/de/qabel/core/event/SubjectEventDispatcherTest.kt
@@ -1,0 +1,26 @@
+package de.qabel.core.event
+
+import de.qabel.core.extensions.letApply
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import rx.observers.TestSubscriber
+
+class SubjectEventDispatcherTest {
+    @Test
+    fun providesFilteredEventStream() {
+        val dispatcher = SubjectEventDispatcher()
+        val testsubscriber = TestSubscriber<Event>()
+
+        dispatcher.events(TestEventA::class.java).subscribe(testsubscriber)
+        dispatcher.push(TestEventB())
+        val eventA: TestEventA = TestEventA().letApply { dispatcher.push(it) }
+
+        val onNextEvents = testsubscriber.onNextEvents
+        assertEquals(1, onNextEvents.size)
+        assertSame(eventA, onNextEvents.first())
+
+    }
+}
+class TestEventA : Event
+class TestEventB : Event


### PR DESCRIPTION
to avoid reoccuring code like
```JAVA
dispatcher
    .events()
    .filter(e -> e is MessageReceivedEvent)
    .map(e -> (MessageReceivedEvent)e)
    .nowTheCodeICareAbout()
```
that can now be written as
```JAVA
dispatcher
    .events(MessageReceivedEvent.class)
    .nowTheCodeICareAbout()
```