### PR TITLE
Update index server

### DIFF
--- a/core/src/main/java/de/qabel/core/index/models.kt
+++ b/core/src/main/java/de/qabel/core/index/models.kt
@@ -138,7 +138,7 @@ data class IdentityStatus(
     /**
      * Current identity data as returned by server (drop URL, alias, public key).
      */
-    val identity: IndexContact,
+    val identity: IndexContact?,
     /**
      * A list of field statuses for every confirmed or unconfirmed (pending) entry associated with the
      * identity.

--- a/core/src/main/java/de/qabel/core/index/server/DeleteIdentityEndpoint.kt
+++ b/core/src/main/java/de/qabel/core/index/server/DeleteIdentityEndpoint.kt
@@ -1,0 +1,9 @@
+package de.qabel.core.index.server
+
+import de.qabel.core.crypto.QblECPublicKey
+import de.qabel.core.index.UpdateIdentity
+import org.apache.http.client.methods.HttpUriRequest
+
+internal interface DeleteIdentityEndpoint : EndpointBase<Unit> {
+    fun buildRequest(identity: UpdateIdentity, serverPublicKey: QblECPublicKey): HttpUriRequest
+}

--- a/core/src/main/java/de/qabel/core/index/server/DeleteIdentityEndpointImpl.kt
+++ b/core/src/main/java/de/qabel/core/index/server/DeleteIdentityEndpointImpl.kt
@@ -1,0 +1,33 @@
+package de.qabel.core.index.server
+
+import com.google.gson.Gson
+import de.qabel.core.crypto.QblECPublicKey
+import de.qabel.core.index.*
+import de.qabel.core.logging.QabelLog
+import org.apache.http.StatusLine
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.client.methods.HttpUriRequest
+
+
+internal class DeleteIdentityEndpointImpl(
+    val location: IndexHTTPLocation,
+    val gson: Gson = createGson()
+) : DeleteIdentityEndpoint, QabelLog {
+    fun buildJsonRequest(identity: UpdateIdentity): String {
+        return gson.toJson(EncryptedApiRequest(
+            api = "delete-identity",
+            timestamp = System.currentTimeMillis() / 1000
+        ))
+    }
+
+    override fun buildRequest(identity: UpdateIdentity, serverPublicKey: QblECPublicKey): HttpUriRequest {
+        val json = buildJsonRequest(identity)
+        val uri = location.getUriBuilderForEndpoint("delete-identity").build()
+        val request = HttpPost(uri)
+        encryptJsonIntoRequest(json, identity.keyPair, serverPublicKey, request)
+        return request
+    }
+
+    override fun parseResponse(jsonString: String, statusLine: StatusLine) {
+    }
+}

--- a/core/src/main/java/de/qabel/core/index/server/IdentityStatusEndpoint.kt
+++ b/core/src/main/java/de/qabel/core/index/server/IdentityStatusEndpoint.kt
@@ -1,0 +1,10 @@
+package de.qabel.core.index.server
+
+import de.qabel.core.crypto.QblECPublicKey
+import de.qabel.core.index.IdentityStatus
+import de.qabel.core.index.UpdateIdentity
+import org.apache.http.client.methods.HttpUriRequest
+
+internal interface IdentityStatusEndpoint : EndpointBase<IdentityStatus> {
+    fun buildRequest(identity: UpdateIdentity, serverPublicKey: QblECPublicKey): HttpUriRequest
+}

--- a/core/src/main/java/de/qabel/core/index/server/IdentityStatusEndpointImpl.kt
+++ b/core/src/main/java/de/qabel/core/index/server/IdentityStatusEndpointImpl.kt
@@ -1,0 +1,44 @@
+package de.qabel.core.index.server
+
+import com.google.gson.Gson
+import de.qabel.core.crypto.QblECPublicKey
+import de.qabel.core.index.*
+import de.qabel.core.logging.QabelLog
+import org.apache.http.StatusLine
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.client.methods.HttpUriRequest
+
+
+internal class IdentityStatusEndpointImpl(
+    val location: IndexHTTPLocation,
+    val gson: Gson = createGson()
+) : IdentityStatusEndpoint, QabelLog {
+    fun buildJsonRequest(identity: UpdateIdentity): String {
+        return gson.toJson(EncryptedApiRequest(
+            api = "status",
+            timestamp = System.currentTimeMillis() / 1000
+        ))
+    }
+
+    override fun buildRequest(identity: UpdateIdentity, serverPublicKey: QblECPublicKey): HttpUriRequest {
+        val json = buildJsonRequest(identity)
+        val uri = location.getUriBuilderForEndpoint("status").build()
+        val request = HttpPost(uri)
+        encryptJsonIntoRequest(json, identity.keyPair, serverPublicKey, request)
+        return request
+    }
+
+    private data class IdentityStatusResponse(
+        val identity: IndexContact,
+        val entries: List<EntryStatus>
+    )
+
+    override fun parseResponse(jsonString: String, statusLine: StatusLine): IdentityStatus {
+        debug("Received identity status response: ${jsonString}")
+        val response = gson.fromJson(jsonString, IdentityStatusResponse::class.java)
+        return IdentityStatus(
+            identity = response.identity,
+            fieldStatus = response.entries
+        )
+    }
+}

--- a/core/src/main/java/de/qabel/core/index/server/IndexHTTP.kt
+++ b/core/src/main/java/de/qabel/core/index/server/IndexHTTP.kt
@@ -13,15 +13,73 @@ internal constructor (
     private val key: ServerPublicKeyEndpoint = ServerPublicKeyEndpointImpl(location),
     private val search: SearchEndpoint = SearchEndpointImpl(location),
     private val update: UpdateEndpoint = UpdateEndpointImpl(location),
+    private val status: IdentityStatusEndpoint = IdentityStatusEndpointImpl(location),
+    private val deleteIdentity: DeleteIdentityEndpoint = DeleteIdentityEndpointImpl(location),
     private val verificationCode: VerificationCodeEndpoint = VerificationCodeEndpointImpl(location)
 ): IndexServer {
     constructor (location: IndexHTTPLocation, httpClient: CloseableHttpClient)
     : this(location, httpClient, ServerPublicKeyEndpointImpl(location))
 
-    override fun search(attributes: Map<FieldType, String>): List<IndexContact> {
-        val request = search.buildRequest(attributes)
+    override fun search(manyAttributes: List<Field>): List<IndexContact> {
+        val request = search.buildRequest(manyAttributes)
         val response = httpClient.execute(request)
         return search.handleResponse(response)
+    }
+
+    override fun search(attributes: Map<FieldType, String>): List<IndexContact> {
+        val request = search.buildRequest(attributes.map {
+            Field(it.key, it.value)
+        })
+        val response = httpClient.execute(request)
+        return search.handleResponse(response)
+    }
+
+    override fun identityStatus(identity: UpdateIdentity): IdentityStatus {
+        return identityStatusWithRetries(identity)
+    }
+
+    fun identityStatus(identity: UpdateIdentity, serverPublicKey: QblECPublicKey): IdentityStatus {
+        val request = status.buildRequest(identity, serverPublicKey)
+        val response = httpClient.execute(request)
+        return status.handleResponse(response)
+    }
+
+    fun identityStatusWithRetries(identity: UpdateIdentity, retries: Int = 0): IdentityStatus {
+        val serverPublicKey = retrieveServerPublicKey()
+        try {
+            return identityStatus(identity, serverPublicKey)
+        } catch (e: APIError) {
+            e.retries = retries
+            if (e.code == HttpStatus.SC_BAD_REQUEST && retries < 2) {
+                // a bad request / 400 may be caused by an outdated server public key, retry two times (total tries = 3)
+                return identityStatusWithRetries(identity, retries + 1)
+            }
+            throw e
+        }
+    }
+
+    override fun deleteIdentity(identity: UpdateIdentity) {
+        return deleteIdentityWithRetries(identity)
+    }
+
+    fun deleteIdentity(identity: UpdateIdentity, serverPublicKey: QblECPublicKey) {
+        val request = deleteIdentity.buildRequest(identity, serverPublicKey)
+        val response = httpClient.execute(request)
+        return deleteIdentity.handleResponse(response)
+    }
+
+    fun deleteIdentityWithRetries(identity: UpdateIdentity, retries: Int = 0) {
+        val serverPublicKey = retrieveServerPublicKey()
+        try {
+            return deleteIdentity(identity, serverPublicKey)
+        } catch (e: APIError) {
+            e.retries = retries
+            if (e.code == HttpStatus.SC_BAD_REQUEST && retries < 2) {
+                // a bad request / 400 may be caused by an outdated server public key, retry two times (total tries = 3)
+                return deleteIdentityWithRetries(identity, retries + 1)
+            }
+            throw e
+        }
     }
 
     override fun updateIdentity(identity: UpdateIdentity): UpdateResult {

--- a/core/src/main/java/de/qabel/core/index/server/IndexServer.kt
+++ b/core/src/main/java/de/qabel/core/index/server/IndexServer.kt
@@ -12,6 +12,15 @@ import java.io.IOException
  */
 interface IndexServer {
     /**
+     * Search for many attributes in one request.
+     *
+     * Returns a list of [IndexContact] instances where each [IndexContact.matches] list is a list of attributes
+     * from [manyAttributes] that matched it. If nothing is found, returns an empty list.
+     */
+    @Throws(IOException::class)
+    fun search(manyAttributes: List<Field>): List<IndexContact>
+
+    /**
      * SearchEndpoint for identities on the index server.
      *
      * At least one attribute has to be specified, or [IllegalArgumentException] will be raised.
@@ -36,6 +45,18 @@ interface IndexServer {
     fun searchForPhone(phone: String): List<IndexContact> {
         return search(mapOf(Pair(FieldType.PHONE, phone)))
     }
+
+    /**
+     * Fetch the [IdentityStatus] of [identity]. [identity.fields] are ignored.
+     */
+    @Throws(IOException::class)
+    fun identityStatus(identity: UpdateIdentity): IdentityStatus
+
+    /**
+     * Delete all data related to [identity] from the index. [identity.fields] are ignored.
+     */
+    @Throws(IOException::class)
+    fun deleteIdentity(identity: UpdateIdentity)
 
     /**
      * UpdateEndpoint published data of [identity] on the index.

--- a/core/src/main/java/de/qabel/core/index/server/IndexServer.kt
+++ b/core/src/main/java/de/qabel/core/index/server/IndexServer.kt
@@ -49,6 +49,9 @@ interface IndexServer {
      * 2. [UpdateField] with the new email address and [UpdateAction.CREATE]
      *
      * As soon as the user confirms the new email address the old email address will be replaced seamlessly.
+     *
+     * The drop URL and alias on the server are updated with the values of [identity] (to only update these,
+     * leave [identity.fields] empty).
      */
     @Throws(IOException::class)
     fun updateIdentity(identity: UpdateIdentity): UpdateResult

--- a/core/src/main/java/de/qabel/core/index/server/SearchEndpoint.kt
+++ b/core/src/main/java/de/qabel/core/index/server/SearchEndpoint.kt
@@ -1,9 +1,9 @@
 package de.qabel.core.index.server
 
-import de.qabel.core.index.FieldType
+import de.qabel.core.index.Field
 import de.qabel.core.index.IndexContact
 import org.apache.http.client.methods.HttpUriRequest
 
 internal interface SearchEndpoint : EndpointBase<List<IndexContact>> {
-    fun buildRequest(attributes: Map<FieldType, String>): HttpUriRequest
+    fun buildRequest(manyAttributes: List<Field>): HttpUriRequest
 }

--- a/core/src/main/java/de/qabel/core/index/server/UpdateEndpointImpl.kt
+++ b/core/src/main/java/de/qabel/core/index/server/UpdateEndpointImpl.kt
@@ -29,19 +29,11 @@ internal class UpdateEndpointImpl(
         return gson.toJson(updateRequest)
     }
 
-    fun encryptJson(json: String, senderKeyPair: QblECKeyPair, serverPublicKey: QblECPublicKey): ByteArray {
-        val box = CryptoUtils().createBox(senderKeyPair, serverPublicKey, json.toByteArray(), 0)
-        return box
-    }
-
     override fun buildRequest(identity: UpdateIdentity, serverPublicKey: QblECPublicKey): HttpUriRequest {
         val json = buildJsonUpdateRequest(identity)
-        val encryptedJson = encryptJson(json, identity.keyPair, serverPublicKey)
-
         val uri = location.getUriBuilderForEndpoint("update").build()
         val request = HttpPut(uri)
-        request.addHeader("Content-Type", "application/vnd.qabel.noisebox+json")
-        request.entity = ByteArrayEntity(encryptedJson)
+        encryptJsonIntoRequest(json, identity.keyPair, serverPublicKey, request)
         return request
     }
 

--- a/core/src/main/java/de/qabel/core/index/server/utils.kt
+++ b/core/src/main/java/de/qabel/core/index/server/utils.kt
@@ -1,0 +1,30 @@
+package de.qabel.core.index.server
+
+import de.qabel.core.crypto.CryptoUtils
+import de.qabel.core.crypto.QblECKeyPair
+import de.qabel.core.crypto.QblECPublicKey
+import de.qabel.core.index.IndexContact
+import de.qabel.core.index.UpdateField
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase
+import org.apache.http.entity.ByteArrayEntity
+
+internal fun encryptJson(json: String, senderKeyPair: QblECKeyPair, serverPublicKey: QblECPublicKey): ByteArray {
+    val box = CryptoUtils().createBox(senderKeyPair, serverPublicKey, json.toByteArray(), 0)
+    return box
+}
+
+
+internal fun encryptJsonIntoRequest(json: String,
+                                    senderKeyPair: QblECKeyPair,
+                                    serverPublicKey: QblECPublicKey,
+                                    request: HttpEntityEnclosingRequestBase) {
+    val encryptedJson = encryptJson(json, senderKeyPair, serverPublicKey)
+    request.addHeader("Content-Type", "application/vnd.qabel.noisebox+json")
+    request.entity = ByteArrayEntity(encryptedJson)
+}
+
+
+internal data class EncryptedApiRequest(
+    val api: String,
+    val timestamp: Long
+)

--- a/core/src/test/java/de/qabel/core/index/server/IndexHTTPTest.kt
+++ b/core/src/test/java/de/qabel/core/index/server/IndexHTTPTest.kt
@@ -9,11 +9,10 @@ import de.qabel.core.index.*
 import org.apache.http.StatusLine
 import org.apache.http.client.methods.HttpUriRequest
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import java.util.*
 
-@Ignore
+
 class IndexHTTPTest {
     private val server = IndexHTTPLocation(TestServer.INDEX)
     private val index = IndexHTTP(server)
@@ -70,16 +69,14 @@ class IndexHTTPTest {
     }
 
     private class UpdateTestParts(private val index: IndexHTTP) {
-        private val mail1 = getRandomMail()
-        private val mail2 = getRandomMail()
+        val mail = getRandomMail()
 
         val identity = UpdateIdentity(
             keyPair = QblECKeyPair(),
             dropURL = DropURL("http://example.net/somewhere/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopo"),
             alias = "Major Anya, Unicode: 裸共產主義",
             fields = listOf(
-                UpdateField(UpdateAction.CREATE, FieldType.EMAIL, mail1),
-                UpdateField(UpdateAction.CREATE, FieldType.EMAIL, mail2)
+                UpdateField(UpdateAction.CREATE, FieldType.EMAIL, mail)
             )
         )
 
@@ -90,22 +87,20 @@ class IndexHTTPTest {
             */
             assertEquals(UpdateResult.ACCEPTED_IMMEDIATE, updateResult)
 
-            /* Will be found with both mails */
-            searchForMailAndAssertOurs(mail1)
-            searchForMailAndAssertOurs(mail2)
+            /* Will be found */
+            searchForMailAndAssertOurs(mail)
         }
 
         fun unpublishTest() {
             val identity = identity.copy(
                 fields = listOf(
-                    UpdateField(UpdateAction.DELETE, FieldType.EMAIL, mail2)
+                    UpdateField(UpdateAction.DELETE, FieldType.EMAIL, mail)
                 )
             )
 
             assertEquals(UpdateResult.ACCEPTED_IMMEDIATE, index.updateIdentity(identity))
 
-            searchForMailAndAssertOurs(mail1)  // still found
-            assertEquals(0, index.search(mapOf(Pair(FieldType.EMAIL, mail2))).size)  // gone
+            assertEquals(0, index.search(mapOf(Pair(FieldType.EMAIL, mail))).size)  // gone
         }
 
         fun assertIdentityEquals(identity: UpdateIdentity, indexContact: IndexContact) {

--- a/core/src/test/java/de/qabel/core/index/server/IndexHTTPTest.kt
+++ b/core/src/test/java/de/qabel/core/index/server/IndexHTTPTest.kt
@@ -68,6 +68,38 @@ class IndexHTTPTest {
         assertEquals(400, exception.code)
     }
 
+    @Test
+    fun testUpdateDropURL() {
+        val testParts = UpdateTestParts(index)
+        testParts.publishTest()
+
+        val updatedIdentity = testParts.identity.copy(dropURL = DropURL("http://example.net/somewhere/abcdefghijklmnopqrstuvwxyzabcdefghijklmonop"))
+        val updateResult = index.updateIdentity(updatedIdentity)
+        assertEquals(UpdateResult.ACCEPTED_IMMEDIATE, updateResult)
+
+        val search1Result = index.search(mapOf(Pair(FieldType.EMAIL, testParts.mail)))
+        assertEquals(1, search1Result.size)
+        val foundPublicIdentity = search1Result[0]
+        assertEquals(updatedIdentity.dropURL, foundPublicIdentity.dropUrl)
+        assertEquals(updatedIdentity.alias, foundPublicIdentity.alias)
+    }
+
+    @Test
+    fun testUpdateAlias() {
+        val testParts = UpdateTestParts(index)
+        testParts.publishTest()
+
+        val updatedIdentity = testParts.identity.copy(alias = "1234")
+        val updateResult = index.updateIdentity(updatedIdentity)
+        assertEquals(UpdateResult.ACCEPTED_IMMEDIATE, updateResult)
+
+        val search1Result = index.search(mapOf(Pair(FieldType.EMAIL, testParts.mail)))
+        assertEquals(1, search1Result.size)
+        val foundPublicIdentity = search1Result[0]
+        assertEquals(updatedIdentity.dropURL, foundPublicIdentity.dropUrl)
+        assertEquals(updatedIdentity.alias, foundPublicIdentity.alias)
+    }
+
     private class UpdateTestParts(private val index: IndexHTTP) {
         val mail = getRandomMail()
 

--- a/core/src/test/java/de/qabel/core/index/server/IndexHTTPTest.kt
+++ b/core/src/test/java/de/qabel/core/index/server/IndexHTTPTest.kt
@@ -110,6 +110,9 @@ class IndexHTTPTest {
 
         val search1Result = index.search(mapOf(Pair(FieldType.EMAIL, testParts.mail)))
         assertEquals(0, search1Result.size)
+
+        val status = index.identityStatus(testParts.identity)
+        assertEquals(null, status.identity)
     }
 
     private class UpdateTestParts(private val index: IndexHTTP) {
@@ -135,7 +138,7 @@ class IndexHTTPTest {
             searchForMailAndAssertOurs(mail)
 
             val status = index.identityStatus(identity)
-            assertIdentityEquals(identity, status.identity)
+            assertIdentityEquals(identity, status.identity!!)
             assertEquals(1, status.fieldStatus.size)
             val field = status.fieldStatus[0]
             assertEquals(EntryStatusEnum.CONFIRMED, field.status)


### PR DESCRIPTION
- [x] Fix IndexHTTPTest
- [x] Document how to update identity properties (drop URL and alias), also add a test for that
- [x] Update search endpoint to use the JSON API of the server
- [x] Add search API to search for a bunch of contacts at once; update IndexContact to have the "matches" property to indicate which contact in the result set belongs to which part of the query
- [x] Add API to query identity status
- [x] Add API to delete identity entirely
- [ ] Reimplement MainIndexService (in progress...)
- [x] Deduplicate retry logic
- [x] Nullable IdentityStatus
- [ ] Fix MainIndexService test
- [ ] Perhaps create lower level tests for the new APIs (<-- most of the existing ones are actually for validating correct use and understanding of gson)

Fixes #600 and implements the new APIs discussed in #615 meeting.