### PR TITLE
optimized PrefixChooser

### DIFF
--- a/box/src/test/java/de/qabel/box/storage/factory/BlockBoxVolumeFactoryTest.kt
+++ b/box/src/test/java/de/qabel/box/storage/factory/BlockBoxVolumeFactoryTest.kt
@@ -99,6 +99,7 @@ class BlockBoxVolumeFactoryTest {
         identity.prefixes = mutableListOf(prefix1, prefix3)
 
         assertThat(choose(CLIENT), equalTo("prefix3"))
+        assertThat(identity.prefixes.last().account ?: "", equalTo("testuser"))
     }
 
     private fun choose(type: Prefix.TYPE = USER) = factory.choosePrefix(identity, account, type)
@@ -121,6 +122,7 @@ class BlockBoxVolumeFactoryTest {
     fun usesRemotePrefixWithIndexIfExistingAndNoLocalIsAvailable() {
         hasRef(prefix2)
         assertThat(choose(), equalTo("prefix2"))
+        assertThat(identity.prefixes.last().account ?: "", equalTo("testuser"))
     }
 
     @Test
@@ -136,5 +138,6 @@ class BlockBoxVolumeFactoryTest {
         identity.prefixes = listOf(prefix2)
 
         assertThat(choose(), equalTo("prefix2"))
+        assertThat(identity.prefixes.last().account ?: "", equalTo("testuser"))
     }
 }

--- a/core/src/test/java/de/qabel/core/accounting/BoxHttpClientTest.java
+++ b/core/src/test/java/de/qabel/core/accounting/BoxHttpClientTest.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.Random;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -135,9 +135,7 @@ public class BoxHttpClientTest {
 
     @Test
     public void createBoxAccount() throws Exception {
-        Random rand = new Random();
-
-        String name = "testUser" + rand.nextInt(10000);
+        String name = ("testUser" + UUID.randomUUID()).substring(0, 30);
         server = serverBuilder.user(name).build();
         boxClient = new BoxHttpClient(server, profile);
         boxClient.createBoxAccount(name + "@example.com");


### PR DESCRIPTION
The `firstOrNull` usages in combination with the replacements of `firstOrElse` -> `?:` make sure that expensive calls like `hasIndex` are only done until one matching candidate prefix was found (because that's sufficient) and is a huge speedup when we have 50+ prefixes like the testaccount.

More important is the 
```KOTLIN
identity.prefixes.add(prefix)
```
it assures that remote-only-prefixes are added to the local identity and can be used on the next use. Otherwise the client would call choose() on every client start which is especially expensive on the TEQS.